### PR TITLE
Fix compile error on iOS

### DIFF
--- a/ios/AutomaticProperties.swift
+++ b/ios/AutomaticProperties.swift
@@ -6,7 +6,7 @@ class AutomaticProperties {
     
     static func setAutomaticProperties(_ properties: [String: Any]) {
         for (key,value) in properties {
-            peopleProperties[key] = MixpanelTypeHandler.ToMixpanelType(value)
+            peopleProperties[key] = MixpanelTypeHandler.mixpanelTypeValue(value)
         }
     }
 }

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -299,7 +299,7 @@ open class MixpanelReactNative: NSObject {
         let mpProperties = MixpanelTypeHandler.processProperties(properties: properties, includeLibInfo: true)
         var mpGroups = Dictionary<String, MixpanelType>()
         for (key,value) in groups ?? [:] {
-            mpGroups[key] = MixpanelTypeHandler.ToMixpanelType(value)
+            mpGroups[key] = MixpanelTypeHandler.mixpanelTypeValue(value)
         }
         instance?.trackWithGroups(event: event, properties: mpProperties, groups: mpGroups)
         resolve(nil)
@@ -310,7 +310,7 @@ open class MixpanelReactNative: NSObject {
                   resolver resolve: RCTPromiseResolveBlock,
                   rejecter reject: RCTPromiseRejectBlock) -> Void {
         let instance = MixpanelReactNative.getMixpanelInstance(token)
-        instance?.setGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.ToMixpanelType(groupID)!)
+        instance?.setGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.mixpanelTypeValue(groupID)!)
         resolve(nil)
     }
     
@@ -319,7 +319,7 @@ open class MixpanelReactNative: NSObject {
                   resolver resolve: RCTPromiseResolveBlock,
                   rejecter reject: RCTPromiseRejectBlock) -> Void {
         let instance = MixpanelReactNative.getMixpanelInstance(token)
-        instance?.addGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.ToMixpanelType(groupID)!)
+        instance?.addGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.mixpanelTypeValue(groupID)!)
         resolve(nil)
     }
     
@@ -328,7 +328,7 @@ open class MixpanelReactNative: NSObject {
                      resolver resolve: RCTPromiseResolveBlock,
                      rejecter reject: RCTPromiseRejectBlock) -> Void {
         let instance = MixpanelReactNative.getMixpanelInstance(token)
-        instance?.removeGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.ToMixpanelType(groupID)!)
+        instance?.removeGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.mixpanelTypeValue(groupID)!)
         resolve(nil)
     }
     
@@ -337,7 +337,7 @@ open class MixpanelReactNative: NSObject {
             return nil
         }
         
-        guard let mixpanelTypeGroupID = MixpanelTypeHandler.ToMixpanelType(groupID) else {
+        guard let mixpanelTypeGroupID = MixpanelTypeHandler.mixpanelTypeValue(groupID) else {
             return nil
         }
         
@@ -391,7 +391,7 @@ open class MixpanelReactNative: NSObject {
                                   resolver resolve: RCTPromiseResolveBlock,
                                   rejecter reject: RCTPromiseRejectBlock) -> Void {
         if let group = mixpanelGroup(token, groupKey: groupKey, groupID: groupID) {
-            guard let mixpanelTypeValue = MixpanelTypeHandler.ToMixpanelType(value) else {
+            guard let mixpanelTypeValue = MixpanelTypeHandler.mixpanelTypeValue(value) else {
                 resolve(nil)
                 return
             }
@@ -407,7 +407,7 @@ open class MixpanelReactNative: NSObject {
                             resolver resolve: RCTPromiseResolveBlock,
                             rejecter reject: RCTPromiseRejectBlock) -> Void {
         if let group = mixpanelGroup(token, groupKey: groupKey, groupID: groupID) {
-            group.union(key: name, values: values.map() { MixpanelTypeHandler.ToMixpanelType($0)! })
+            group.union(key: name, values: values.map() { MixpanelTypeHandler.mixpanelTypeValue($0)! })
         }
         resolve(nil)
     }


### PR DESCRIPTION
```
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:302:49: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
            mpGroups[key] = MixpanelTypeHandler.ToMixpanelType(value)
                            ~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:313:77: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
        instance?.setGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.ToMixpanelType(groupID)!)
                                                        ~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:322:77: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
        instance?.addGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.ToMixpanelType(groupID)!)
                                                        ~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:331:80: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
        instance?.removeGroup(groupKey: groupKey, groupID: MixpanelTypeHandler.ToMixpanelType(groupID)!)
                                                           ~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:340:61: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
        guard let mixpanelTypeGroupID = MixpanelTypeHandler.ToMixpanelType(groupID) else {
                                        ~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:394:63: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
            guard let mixpanelTypeValue = MixpanelTypeHandler.ToMixpanelType(value) else {
                                          ~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
/node_modules/mixpanel-react-native/ios/MixpanelReactNative.swift:410:79: error: type 'MixpanelTypeHandler' has no member 'ToMixpane
lType'
            group.union(key: name, values: values.map() { MixpanelTypeHandler.ToMixpanelType($0)! })
```

It would have caused by [this change](https://github.com/mixpanel/mixpanel-react-native/pull/48)