### PR TITLE
Deprecate the class method init() and improve the example

### DIFF
--- a/MixpanelDemo/Analytics.js
+++ b/MixpanelDemo/Analytics.js
@@ -1,14 +1,15 @@
 import {Mixpanel} from 'mixpanel-react-native';
 import {token as MixpanelToken} from './app.json';
 
-export default class MixpanelManager {
+
+export class MixpanelManager {
     static sharedInstance = MixpanelManager.sharedInstance || new MixpanelManager();
 
     constructor() {
-        this.configMixpanel();
-    }
-    
-    configMixpanel = async () => {
-        this.mixpanel = await Mixpanel.init(MixpanelToken);
+        this.mixpanel = new Mixpanel(MixpanelToken);
+        this.mixpanel.init();
+        this.mixpanel.setLoggingEnabled(true);
     }
 }
+
+export const MixpanelInstance = MixpanelManager.sharedInstance.mixpanel;

--- a/MixpanelDemo/screens/EventScreen.js
+++ b/MixpanelDemo/screens/EventScreen.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import {View, Text, StyleSheet, TouchableOpacity, ScrollView} from 'react-native';
 
-import MixpanelManager from '../Analytics';
+import {MixpanelInstance} from '../Analytics';
+
 
 class EventScreen extends React.Component {
 
     constructor(props) {
         super(props);
-        this.mixpanel = MixpanelManager.sharedInstance.mixpanel;
+        this.mixpanel = MixpanelInstance;
     }
 
     /**

--- a/MixpanelDemo/screens/GDPRScreen.js
+++ b/MixpanelDemo/screens/GDPRScreen.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {Text, TouchableOpacity, StyleSheet, View, ScrollView} from 'react-native';
-import MixpanelManager from '../Analytics';
+import {MixpanelInstance} from '../Analytics';
 
 export default class GDPRScreen extends React.Component {
 
     constructor(props) {
         super(props);
-        this.mixpanel = MixpanelManager.sharedInstance.mixpanel;
+        this.mixpanel = MixpanelInstance;
     }
 
     /**

--- a/MixpanelDemo/screens/GroupScreen.js
+++ b/MixpanelDemo/screens/GroupScreen.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {Text, TouchableOpacity, StyleSheet, View, ScrollView} from 'react-native';
-import MixpanelManager from '../Analytics';
+import {MixpanelInstance} from '../Analytics';
 
 export default class GroupScreen extends React.Component {
 
     constructor(props) {
         super(props);
-        this.mixpanel = MixpanelManager.sharedInstance.mixpanel;
+        this.mixpanel = MixpanelInstance;
         this.group = this.mixpanel.getGroup("company_id", 12345);
     }
 
@@ -15,7 +15,7 @@ export default class GroupScreen extends React.Component {
     }
 
     setPropertyOnce = () => {
-        this.group.setOnce("prop_key", "prop_value").then(t => alert("success"));
+        this.group.setOnce("prop_key", "prop_value");
     }
 
     unsetProperty = () => {

--- a/MixpanelDemo/screens/ProfileScreen.js
+++ b/MixpanelDemo/screens/ProfileScreen.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {Text, TouchableOpacity, StyleSheet, View, ScrollView} from 'react-native';
-import MixpanelManager from '../Analytics';
+import {MixpanelInstance} from '../Analytics';
 
 export default class ProfileScreen extends React.Component {
 
     constructor(props) {
         super(props);
-        this.mixpanel = MixpanelManager.sharedInstance.mixpanel;
+        this.mixpanel = MixpanelInstance;
     }
     
     createAlias = () => {
@@ -22,15 +22,15 @@ export default class ProfileScreen extends React.Component {
           "a": 1,
           "b": 2.3,
           "c": ["4", 5],
-        }).then(t => alert("success"));
+        });
     }
 
     setOneProperty = () => {
-        this.mixpanel.getPeople().set("d", "yo").then(t => alert("success"));
+        this.mixpanel.getPeople().set("d", "yo");
     }
 
     setOnePropertyOnce = () => {
-        this.mixpanel.getPeople().setOnce("c", "just once").then(t => alert("success"));
+        this.mixpanel.getPeople().setOnce("c", "just once");
     }
 
     unsetProperties = () => {
@@ -54,11 +54,11 @@ export default class ProfileScreen extends React.Component {
     }
 
     trackChargeWithoutProperties = () => {
-        this.mixpanel.getPeople().trackCharge(22.8).then(t => alert("success"));
+        this.mixpanel.getPeople().trackCharge(22.8);
     }
 
     trackCharge = () => {
-        this.mixpanel.getPeople().trackCharge(12.8, {"sandwich": 1}).then(t => alert("success"));
+        this.mixpanel.getPeople().trackCharge(12.8, {"sandwich": 1});
     }
 
     clearCharges = () => {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [Initialize Mixpanel](#2-initialize-mixpanel)
     - [Send Data](#3-send-data)
     - [Check for Success](#4-check-for-success)
+    - [Complete Code Example](#complete-code-example)
 - [FAQ](#faq)
 - [I want to know more!](#i-want-to-know-more)
 
@@ -48,24 +49,18 @@ Please note: You do not need to update your Podfile to add Mixpanel.
 
 
 ### 2. Initialize Mixpanel
-To start tracking with the library you must first initialize with your project token. To initialize the library, first add `import { Mixpanel }` and call `Mixpanel.init(token)` with your project token as it's argument. 
+To start tracking with the library you must first initialize with your project token. You can get your project token from [project settings](https://mixpanel.com/settings/project).
+
 ```js
 import { Mixpanel } from 'mixpanel-react-native';
-...
-class YourClass extends React.Component {
-    constructor(props) {
-        super(props);
-        this.configMixpanel();
-    }
 
-    configMixpanel = async () => {
-        this.mixpanel = await Mixpanel.init("Your mixpanel token");
-    }
-...
+const mixpanel = new Mixpanel("Your Project Token");
+mixpanel.init();
+
 ```
 Once you've called this method once, you can access `mixpanel` throughout the rest of your application.
 ### 3. Send Data
-Let's get started by sending event data. You can send an event from anywhere in your application. Better understand user behavior by storing details that are specific to the event (properties). After initializing the library, Mixpanel will [automatically collect common mobile events](https://mixpanel.com/help/questions/articles/which-common-mobile-events-can-mixpanel-collect-on-my-behalf-automatically). You can enable/disable automatic collection through your project settings. Also, Mixpanel automatically tracks some properties by default. [learn more](https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel)
+Let's get started by sending event data. You can send an event from anywhere in your application. Better understand user behavior by storing details that are specific to the event (properties). After initializing the library, Mixpanel will automatically track some properties by default. [learn more](https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel)
 ```js
 // Track with event-name
 mixpanel.track('Sent Message');
@@ -77,6 +72,33 @@ In addition to event data, you can also send [user profile data](https://develop
 [Open up Live View in Mixpanel](http://mixpanel.com/report/live)  to view incoming events.
 Once data hits our API, it generally takes ~60 seconds for it to be processed, stored, and queryable in your project.
 <a name="i-want-to-know-more"></a>
+
+### Complete Code Example
+```js
+
+import React from 'react';
+import {Button,SafeAreaView} from "react-native";
+import {Mixpanel} from 'mixpanel-react-native';
+
+const mixpanel = new Mixpanel("Your Project Token");
+mixpanel.init();
+
+export function SampleApp() {
+  return (
+    <SafeAreaView>
+      <Button
+        title="Select Premium Plan"
+        onPress={() => mixpanel.track("Plan Selected", {"Plan": "Premium"})}
+      />
+    </SafeAreaView>
+  );
+}
+
+export default SampleApp;
+
+```
+
+
 
 ## FAQ
 **I want to stop tracking an event/event property in Mixpanel. Is that possible?**  

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ type MixpanelProperties = { [key: string]: MixpanelType };
 
 export class Mixpanel {
     static init(token: string, optInTracking?: boolean): Promise<Mixpanel>;
+    init(optInTracking?: boolean): Promise<void>;
     setServerURL(serverURL: string): void;
     setLoggingEnabled(loggingEnabled: boolean): void;
     setUseIpAddressForGeolocation(useIpAddressForGeolocation: boolean): void;

--- a/index.js
+++ b/index.js
@@ -51,8 +51,25 @@ export class Mixpanel {
     }
 
     /**
-     * Initializes an instance of the API with the given project token.
+     * Initializes Mixpanel
+     *
+     * @param {boolean} Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()
+     *
+     */
+    async init(optOutTrackingDefault = DEFAULT_OPT_OUT) {
+        let metadata = Helper.getMetaData();
+        await MixpanelReactNative.initialize(this.token, optOutTrackingDefault, metadata);
+    }
+
+    /**
+     * @deprecated since version 1.3.0. To initialize Mixpanel, please use the instance method `init` instead. See the example below:
+     *
+     * <pre><code>
+     * const mixpanel = new Mixpanel('your project token');
+     * mixpanel.init();
+     * </code></pre>
      * 
+     * Initializes Mixpanel and return an instance of Mixpanel the given project token.
      *
      * @param {string} token your project token.
      * @param {boolean} Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -19,6 +19,8 @@ open class MixpanelReactNative: NSObject {
                     rejecter reject: RCTPromiseRejectBlock) -> Void {
         AutomaticProperties.setAutomaticProperties(properties)
         Mixpanel.initialize(token: token, launchOptions: nil, flushInterval: Constants.DEFAULT_FLUSH_INTERVAL, instanceName: token, automaticPushTracking: Constants.AUTOMATIC_PUSH_TRACKING, optOutTrackingByDefault: optOutTrackingByDefault)
+        let instance = MixpanelReactNative.getMixpanelInstance(token)
+        instance?.trackAutomaticEventsEnabled = false
         resolve(true)
     }
 


### PR DESCRIPTION
Deprecating the class method `init()`. To initialize Mixpanel, please use the instance method `init()` instead. See the example below:
 
```
   const mixpanel = new Mixpanel('your project token');
   mixpanel.init();
```