### PR TITLE
Add constructor method type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export class People {
 }
 
 export class MixpanelGroup {
-    constructor(token: string, groupKey: string, groupID: string);
+    constructor(token: string, groupKey: string, groupID: MixpanelType);
     set(prop: string, to: MixpanelType): void;
     setOnce(prop: string, to: MixpanelType): void;
     unset(prop: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ type MixpanelType = any;
 type MixpanelProperties = { [key: string]: MixpanelType };
 
 export class Mixpanel {
+    constructor(token: string);
     static init(token: string, optOutTrackingDefault?: boolean): Promise<Mixpanel>;
     init(optOutTrackingDefault?: boolean): Promise<void>;
     setServerURL(serverURL: string): void;
@@ -33,6 +34,7 @@ export class Mixpanel {
 }
 
 export class People {
+    constructor(token: string);
     set(prop: string, to: MixpanelType): void;
     setOnce(prop: string, to: MixpanelType): void;
     increment(prop: string, by: number): void;
@@ -46,6 +48,7 @@ export class People {
 }
 
 export class MixpanelGroup {
+    constructor(token: string, groupKey: string, groupID: string);
     set(prop: string, to: MixpanelType): void;
     setOnce(prop: string, to: MixpanelType): void;
     unset(prop: string): void;


### PR DESCRIPTION
This solves the following TypeScript error addressed in #83:

```ts
const mixpanel = new Mixpanel("Your Project Token"); // Expected 0 arguments, but got 1.
```