### PR TITLE
Incomplete types for set function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export class Mixpanel {
 
 export class People {
     constructor(token: string);
-    set(prop: string, to: MixpanelType): void;
+    set(prop: string | Record<string, string | boolean | null | number | string[] | number[]>, to: MixpanelType): void;
     setOnce(prop: string, to: MixpanelType): void;
     increment(prop: string, by: number): void;
     append(name: string, value: MixpanelType): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export class Mixpanel {
 
 export class People {
     constructor(token: string);
-    set(prop: string | Record<string, string | boolean | null | number | string[] | number[]>, to: MixpanelType): void;
+    set(prop: string | Record<string, string | boolean | null | number | string[] | number[]>, to?: MixpanelType): void;
     setOnce(prop: string, to: MixpanelType): void;
     increment(prop: string, by: number): void;
     append(name: string, value: MixpanelType): void;


### PR DESCRIPTION
From the help docs of mix panel it seems that any user profile property can only be either of String, Boolean, Numeric or List. Hence based on that I have added the following union type `string | boolean | null | number | string[] | number[]`
This should cover all the valid property types. Let me know if any are missing or if I have added a type that is not supported.