### PR TITLE
Fix Expo SDK 44 build error

### DIFF
--- a/ios/MixpanelReactNative-Bridging-Header.h
+++ b/ios/MixpanelReactNative-Bridging-Header.h
@@ -1,5 +1,1 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif


### PR DESCRIPTION
Building our app which uses Expo SDK 44 (latest version) fails. This is because expo patches the react podspec for swift compatibility reasons and that causes old style imports to not work.

I fixed the issue by changing the import style. 

More information: https://github.com/expo/expo/issues/15622#issuecomment-997141629

```
› Compiling mixpanel-react-native Pods/MixpanelReactNative » AutomaticProperties.swift

❌  (/Users/yonom/Documents/GitHub/app/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:424:1)

  422 |  * A class that allows NativeModules and TurboModules to look up one another.
  423 |  */
> 424 | @interface RCTModuleRegistry : NSObject
      | ^ duplicate interface definition for class 'RCTModuleRegistry'
  425 | - (void)setBridge:(RCTBridge *)bridge;
  426 | - (void)setTurboModuleRegistry:(id<RCTTurboModuleRegistry>)turboModuleRegistry;
  427 | 

```