### PR TITLE
Allow disable flush on background

### DIFF
--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -20,6 +20,7 @@ jest.doMock('react-native', () => {
           initialize: jest.fn(),
           setServerURL: jest.fn(),
           setLoggingEnabled: jest.fn(),
+          setFlushOnBackground: jest.fn(),
           setUseIpAddressForGeolocation: jest.fn(),
           hasOptedOutTracking: jest.fn(),
           optInTracking: jest.fn(),

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -68,6 +68,15 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setFlushOnBackground(final String token, boolean flushOnBackground, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+        synchronized (instance) {
+            instance.setFlushOnBackground(flushOnBackground);
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
     public void hasOptedOutTracking(final String token, Promise promise) {
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
         synchronized (instance) {

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -68,15 +68,6 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setFlushOnBackground(final String token, boolean flushOnBackground, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
-        synchronized (instance) {
-            instance.setFlushOnBackground(flushOnBackground);
-            promise.resolve(null);
-        }
-    }
-
-    @ReactMethod
     public void hasOptedOutTracking(final String token, Promise promise) {
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
         synchronized (instance) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@ export class Mixpanel {
     init(optOutTrackingDefault?: boolean, superProperties?: MixpanelProperties): Promise<void>;
     setServerURL(serverURL: string): void;
     setLoggingEnabled(loggingEnabled: boolean): void;
+    setFlushOnBackground(flushOnBackground: boolean): void;
+
     setUseIpAddressForGeolocation(useIpAddressForGeolocation: boolean): void;
     hasOptedOutTracking(): Promise<boolean>;
     optInTracking(): void;

--- a/index.js
+++ b/index.js
@@ -106,6 +106,17 @@ export class Mixpanel {
         MixpanelReactNative.setLoggingEnabled(this.token, loggingEnabled);
     }
 
+     /**
+     * This allows enabling or disabling whether or not Mixpanel flushes events.
+     * when the app enters the background. This is set to true by default. 
+     *
+     * @param {boolean} flushOnBackground whether to enable logging
+     *
+     */
+    setFlushOnBackground(flushOnBackground) {
+        MixpanelReactNative.setFlushOnBackground(this.token, flushOnBackground);
+    }
+
     /**
      * This controls whether to automatically send the client IP Address as part of event tracking.
      * With an IP address, geo-location is possible down to neighborhoods within a city,

--- a/index.js
+++ b/index.js
@@ -107,14 +107,18 @@ export class Mixpanel {
     }
 
      /**
-     * This allows enabling or disabling whether or not Mixpanel flushes events.
-     * when the app enters the background. This is set to true by default. 
+     * This allows enabling or disabling whether or not Mixpanel flushes events
+     * when the app enters the background on iOS. This is set to true by default. 
      *
      * @param {boolean} flushOnBackground whether to enable logging
      *
      */
     setFlushOnBackground(flushOnBackground) {
-        MixpanelReactNative.setFlushOnBackground(this.token, flushOnBackground);
+        if (Platform.OS === 'ios') {
+            MixpanelReactNative.setFlushOnBackground(this.token, flushOnBackground);
+        } else {
+            console.warn('Mixpanel setFlushOnBackground was called and ignored because this method only works on iOS.')
+        }
     }
 
     /**

--- a/ios/MixpanelReactNative.m
+++ b/ios/MixpanelReactNative.m
@@ -12,6 +12,8 @@ RCT_EXTERN_METHOD(setServerURL:(NSString *)token serverURL:(NSString *)serverURL
 
 RCT_EXTERN_METHOD(setLoggingEnabled:(NSString *)token loggingEnabled:(BOOL)loggingEnabled resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setFlushOnBackground:(NSString *)token flushOnBackground:(BOOL)flushOnBackground resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(setUseIpAddressForGeolocation:(NSString *)token useIpAddressForGeolocation:(BOOL)useIpAddressForGeolocation resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 // MARK: - Opting Users Out of Tracking

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -45,6 +45,16 @@ open class MixpanelReactNative: NSObject {
     }
 
     @objc
+    func setFlushOnBackground(_ token: String,
+                    flushOnBackground: Bool,
+                    resolver resolve: RCTPromiseResolveBlock,
+                    rejecter reject: RCTPromiseRejectBlock) -> Void {
+        let instance = MixpanelReactNative.getMixpanelInstance(token)
+        instance?.flushOnBackground = flushOnBackground
+        resolve(nil)
+    }
+
+    @objc
     func setUseIpAddressForGeolocation(_ token: String,
                     useIpAddressForGeolocation: Bool,
                     resolver resolve: RCTPromiseResolveBlock,


### PR DESCRIPTION
Mixpanel is causing occasional terminations 30 seconds after our app enters the background due to long-running background tasks. 


> [BackgroundTask] Background Task 113 ("Called by Siro, from $s8Mixpanel0A8InstanceC29applicationDidEnterBackground33_0CB45E1C8B4A4433813A640264188496LLyy10Foundation12NotificationVF"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call UIApplication.endBackgroundTask(_:) for your task in a timely manner to avoid this.


Adding the ability to disable flush on entering background allows us to sidestep this issue.

Future work should be done to alow Mixpanel to fail gracefully if a background task is taking too long rather than causing app to terminate.