### PR TITLE
make trackAutomaticEvents required and bump versions to deprecate Decide

### DIFF
--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }  
   
   s.dependency "React"
-  s.dependency "Mixpanel-swift", '4.0.0'
+  s.dependency "Mixpanel-swift", '4.0.1'
 end

--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }  
   
   s.dependency "React"
-  s.dependency "Mixpanel-swift", '3.3.0'
+  s.dependency "Mixpanel-swift", '4.0.0'
 end

--- a/Samples/ContextAPIMixpanel/Analytics.js
+++ b/Samples/ContextAPIMixpanel/Analytics.js
@@ -9,7 +9,8 @@ export const MixpanelProvider = ({children}) => {
   const [mixpanel, setMixpanel] = React.useState(null);
 
   React.useEffect(() => {
-    const mixpanelInstance = new Mixpanel(`Your Project Token`);
+    const trackAutomaticEvents = true;
+    const mixpanelInstance = new Mixpanel(`Your Project Token`, trackAutomaticEvents);
     mixpanelInstance.init();
     setMixpanel(mixpanelInstance);
   }, []);

--- a/Samples/MixpanelDemo/Analytics.js
+++ b/Samples/MixpanelDemo/Analytics.js
@@ -1,12 +1,12 @@
 import {Mixpanel} from 'mixpanel-react-native';
-import {token as MixpanelToken} from './app.json';
+import {token as MixpanelToken, trackAutomaticEvents} from './app.json';
 
 
 export class MixpanelManager {
     static sharedInstance = MixpanelManager.sharedInstance || new MixpanelManager();
 
     constructor() {
-        this.mixpanel = new Mixpanel(MixpanelToken);
+        this.mixpanel = new Mixpanel(MixpanelToken, trackAutomaticEvents);
         this.mixpanel.init();
         this.mixpanel.setLoggingEnabled(true);
     }

--- a/Samples/MixpanelDemo/app.json
+++ b/Samples/MixpanelDemo/app.json
@@ -1,5 +1,6 @@
 {
   "name": "MixpanelDemo",
   "displayName": "MixpanelDemo",
-  "token": "YOUR_PROJECT_TOKEN"
+  "token": "YOUR_PROJECT_TOKEN",
+  "trackAutomaticEvents": true
 }

--- a/Samples/SimpleMixpanel/App.js
+++ b/Samples/SimpleMixpanel/App.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { Button, SafeAreaView } from "react-native";
 import { Mixpanel } from 'mixpanel-react-native';
 
-const mixpanel = new Mixpanel("Your Project Token");
+const trackAutomaticEvents = true;
+const mixpanel = new Mixpanel("Your Project Token", trackAutomaticEvents);
 mixpanel.init();
 
 // *************************************

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -13,8 +13,8 @@ test(`it calls MixpanelReactNative initialize`, async () => {
 });
 
 test(`it calls MixpanelReactNative initialize with optOut and superProperties`, async () => {
-  const mixpanel = new Mixpanel("token");
-  mixpanel.init(true, true, {"super": "property"})
+  const mixpanel = new Mixpanel("token", true);
+  mixpanel.init(true, {"super": "property"})
   expect(NativeModules.MixpanelReactNative.initialize).toBeCalledWith("token", true, true, {"$lib_version": "1.5.0", "mp_lib": "react-native", "super": "property"});
 });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -8,103 +8,103 @@ import { NativeModules } from 'react-native';
 
 
 test(`it calls MixpanelReactNative initialize`, async () => {
-  const mixpanel = await Mixpanel.init("token");
-  expect(NativeModules.MixpanelReactNative.initialize).toBeCalledWith("token", false, {"$lib_version": "1.5.0", "mp_lib": "react-native"});
+  const mixpanel = await Mixpanel.init("token", true);
+  expect(NativeModules.MixpanelReactNative.initialize).toBeCalledWith("token", true, false, {"$lib_version": "1.5.0", "mp_lib": "react-native"});
 });
 
 test(`it calls MixpanelReactNative initialize with optOut and superProperties`, async () => {
   const mixpanel = new Mixpanel("token");
-  mixpanel.init(true, {"super": "property"})
-  expect(NativeModules.MixpanelReactNative.initialize).toBeCalledWith("token", true, {"$lib_version": "1.5.0", "mp_lib": "react-native", "super": "property"});
+  mixpanel.init(true, true, {"super": "property"})
+  expect(NativeModules.MixpanelReactNative.initialize).toBeCalledWith("token", true, true, {"$lib_version": "1.5.0", "mp_lib": "react-native", "super": "property"});
 });
 
 test(`it calls MixpanelReactNative setServerURL`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.setServerURL("https://api-eu.mixpanel.com");
   expect(NativeModules.MixpanelReactNative.setServerURL).toBeCalledWith("token", "https://api-eu.mixpanel.com");
 });
 
 test(`it calls MixpanelReactNative setLoggingEnabled`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.setLoggingEnabled(true);
   expect(NativeModules.MixpanelReactNative.setLoggingEnabled).toBeCalledWith("token", true);
 });
 
 test(`it calls MixpanelReactNative setUseIpAddressForGeolocation`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.setUseIpAddressForGeolocation(true);
   expect(NativeModules.MixpanelReactNative.setUseIpAddressForGeolocation).toBeCalledWith("token", true);
 });
 
 test(`it calls MixpanelReactNative hasOptedOutTracking`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.hasOptedOutTracking();
   expect(NativeModules.MixpanelReactNative.hasOptedOutTracking).toBeCalledWith("token");
 });
 
 
 test(`it calls MixpanelReactNative optInTracking`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.optInTracking();
   expect(NativeModules.MixpanelReactNative.optInTracking).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative optOutTracking`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.optOutTracking();
   expect(NativeModules.MixpanelReactNative.optOutTracking).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative identify`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.identify("distinct_id");
   expect(NativeModules.MixpanelReactNative.identify).toBeCalledWith("token", "distinct_id");
 });
 
 test(`it calls MixpanelReactNative alias`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.alias("alias", "distinct_id");
   expect(NativeModules.MixpanelReactNative.alias).toBeCalledWith("token", "alias", "distinct_id");
 });
 
 test(`it calls MixpanelReactNative track`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.track("event name",  {"Cool Property": "Property Value"});
   expect(NativeModules.MixpanelReactNative.track).toBeCalledWith("token", "event name",  {"Cool Property": "Property Value"});
 });
 
 test(`it calls MixpanelReactNative trackWithGroups`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.trackWithGroups("tracked with groups", {"a": 1, "b": 2.3}, {"company_id": "Mixpanel"});
   expect(NativeModules.MixpanelReactNative.trackWithGroups).toBeCalledWith("token", "tracked with groups", {"a": 1, "b": 2.3}, {"company_id": "Mixpanel"});
 });
 
 test(`it calls MixpanelReactNative setGroup`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.setGroup("company_id", 12345);
   expect(NativeModules.MixpanelReactNative.setGroup).toBeCalledWith("token", "company_id", 12345);
 });
 
 test(`it calls MixpanelReactNative addGroup`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.addGroup("company_id", 12345);
   expect(NativeModules.MixpanelReactNative.addGroup).toBeCalledWith("token", "company_id", 12345);
 });
 
 test(`it calls MixpanelReactNative removeGroup`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.removeGroup("company_id", 12345);
   expect(NativeModules.MixpanelReactNative.removeGroup).toBeCalledWith("token", "company_id", 12345);
 });
 
 test(`it calls MixpanelReactNative deleteGroup`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.deleteGroup("company_id", 12345);
   expect(NativeModules.MixpanelReactNative.deleteGroup).toBeCalledWith("token", "company_id", 12345);
 });
 
 test(`it calls MixpanelReactNative registerSuperProperties`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.registerSuperProperties({
     "super property": "super property value",
     "super property1": "super property value1",
@@ -116,7 +116,7 @@ test(`it calls MixpanelReactNative registerSuperProperties`, async () => {
 });
 
 test(`it calls MixpanelReactNative registerSuperPropertiesOnce`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.registerSuperPropertiesOnce({
     "super property": "super property value",
     "super property1": "super property value1",
@@ -128,49 +128,49 @@ test(`it calls MixpanelReactNative registerSuperPropertiesOnce`, async () => {
 });
 
 test(`it calls MixpanelReactNative unregisterSuperProperty`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.unregisterSuperProperty("super property");
   expect(NativeModules.MixpanelReactNative.unregisterSuperProperty).toBeCalledWith("token", "super property");
 });
 
 test(`it calls MixpanelReactNative getSuperProperties`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getSuperProperties();
   expect(NativeModules.MixpanelReactNative.getSuperProperties).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative clearSuperProperties`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.clearSuperProperties();
   expect(NativeModules.MixpanelReactNative.clearSuperProperties).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative timeEvent`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.timeEvent("Timed Event");
   expect(NativeModules.MixpanelReactNative.timeEvent).toBeCalledWith("token", "Timed Event");
 });
 
 test(`it calls MixpanelReactNative eventElapsedTime`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.eventElapsedTime("Timed Event");
   expect(NativeModules.MixpanelReactNative.eventElapsedTime).toBeCalledWith("token", "Timed Event");
 });
 
 test(`it calls MixpanelReactNative reset`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.reset();
   expect(NativeModules.MixpanelReactNative.reset).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative getDistinctId`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getDistinctId();
   expect(NativeModules.MixpanelReactNative.getDistinctId).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative profile set`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().set({
     "a": 1,
     "b": 2.3,
@@ -187,7 +187,7 @@ test(`it calls MixpanelReactNative profile set`, async () => {
 });
 
 test(`it calls MixpanelReactNative profile setOnce`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().setOnce({
     "a": 1,
     "b": 2.3,
@@ -204,7 +204,7 @@ test(`it calls MixpanelReactNative profile setOnce`, async () => {
 });
 
 test(`it calls MixpanelReactNative profile increment`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().increment({
     "a": 1,
     "b": 2.3,
@@ -219,73 +219,73 @@ test(`it calls MixpanelReactNative profile increment`, async () => {
 });
 
 test(`it calls MixpanelReactNative profile append`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().append("a", "1");
   expect(NativeModules.MixpanelReactNative.append).toBeCalledWith("token", {"a": "1"});
 });
 
 test(`it calls MixpanelReactNative profile union`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().union("a1", "1");
   expect(NativeModules.MixpanelReactNative.union).toBeCalledWith("token", {"a1": ["1"]});
 });
 
 test(`it calls MixpanelReactNative profile remove`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().remove("a", "1");
   expect(NativeModules.MixpanelReactNative.remove).toBeCalledWith("token", {"a": "1"});
 });
 
 test(`it calls MixpanelReactNative profile unset`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().unset("a");
   expect(NativeModules.MixpanelReactNative.unset).toBeCalledWith("token", "a");
 });
 
 test(`it calls MixpanelReactNative profile trackCharge`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().trackCharge(22.8);
   expect(NativeModules.MixpanelReactNative.trackCharge).toBeCalledWith("token", 22.8, {});
 });
 
 test(`it calls MixpanelReactNative profile clearCharges`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().clearCharges();
   expect(NativeModules.MixpanelReactNative.clearCharges).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative profile deleteUser`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getPeople().deleteUser();
   expect(NativeModules.MixpanelReactNative.deleteUser).toBeCalledWith("token");
 });
 
 test(`it calls MixpanelReactNative group set properties`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getGroup("company_id", 12345).set("prop_key", "prop_value");
   expect(NativeModules.MixpanelReactNative.groupSetProperties).toBeCalledWith("token", "company_id", 12345, {"prop_key": "prop_value"});
 });
 
 test(`it calls MixpanelReactNative group set property once`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getGroup("company_id", 12345).setOnce("prop_key", "prop_value");
   expect(NativeModules.MixpanelReactNative.groupSetPropertyOnce).toBeCalledWith("token", "company_id", 12345, {"prop_key": "prop_value"});
 });
 
 test(`it calls MixpanelReactNative group unset property`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getGroup("company_id", 12345).unset("prop_key");
   expect(NativeModules.MixpanelReactNative.groupUnsetProperty).toBeCalledWith("token", "company_id", 12345, "prop_key");
 });
 
 test(`it calls MixpanelReactNative group remove property`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getGroup("company_id", 12345).remove("prop_key", "334");
   expect(NativeModules.MixpanelReactNative.groupRemovePropertyValue).toBeCalledWith("token", "company_id", 12345, "prop_key", "334");
 });
 
 test(`it calls MixpanelReactNative group union property`, async () => {
-  const mixpanel = await Mixpanel.init("token");
+  const mixpanel = await Mixpanel.init("token", true);
   mixpanel.getGroup("company_id", 12345).union("prop_key", "334");
   expect(NativeModules.MixpanelReactNative.groupRemovePropertyValue).toBeCalledWith("token", "company_id", 12345, "prop_key", "334");
 });

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:6.3.0'
+    implementation 'com.mixpanel.android:mixpanel-android:7.0.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:7.0.0'
+    implementation 'com.mixpanel.android:mixpanel-android:7.0.1'
 }

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -33,10 +33,10 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
 
 
     @ReactMethod
-    public void initialize(String token, boolean optOutTrackingDefault, ReadableMap metadata, Promise promise) throws JSONException {
+    public void initialize(String token, boolean trackAutomaticEvents, boolean optOutTrackingDefault, ReadableMap metadata, Promise promise) throws JSONException {
         JSONObject mixpanelProperties = ReactNativeHelper.reactToJSON(metadata);
         AutomaticProperties.setAutomaticProperties(mixpanelProperties);
-        MixpanelAPI.getInstance(this.mReactContext, token, optOutTrackingDefault, mixpanelProperties);
+        MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents, optOutTrackingDefault, mixpanelProperties);
         promise.resolve(null);
     }
 

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -41,8 +41,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setServerURL(final String token, final String serverURL, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void setServerURL(final String token, final boolean trackAutomaticEvents, final String serverURL, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.setServerURL(serverURL);
             promise.resolve(null);
@@ -50,8 +50,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setUseIpAddressForGeolocation(final String token, boolean useIpAddressForGeolocation, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void setUseIpAddressForGeolocation(final String token, final boolean trackAutomaticEvents, boolean useIpAddressForGeolocation, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.setUseIpAddressForGeolocation(useIpAddressForGeolocation);
             promise.resolve(null);
@@ -59,8 +59,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setLoggingEnabled(final String token, boolean enableLogging, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void setLoggingEnabled(final String token, final boolean trackAutomaticEvents, boolean enableLogging, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.setEnableLogging(enableLogging);
             promise.resolve(null);
@@ -68,16 +68,16 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void hasOptedOutTracking(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void hasOptedOutTracking(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             promise.resolve(instance.hasOptedOutTracking());
         }
     }
 
     @ReactMethod
-    public void optInTracking(final String token, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void optInTracking(final String token, final boolean trackAutomaticEvents, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.optInTracking();
             promise.resolve(null);
@@ -85,8 +85,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void optOutTracking(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void optOutTracking(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.optOutTracking();
             promise.resolve(null);
@@ -94,8 +94,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void identify(final String token, final String distinctId, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void identify(final String token, final boolean trackAutomaticEvents, final String distinctId, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.identify(distinctId);
             promise.resolve(null);
@@ -103,24 +103,24 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getDistinctId(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void getDistinctId(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             promise.resolve(instance.getDistinctId());
         }
     }
 
     @ReactMethod
-    public void getDeviceId(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void getDeviceId(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             promise.resolve(instance.getAnonymousId());
         }
     }
 
     @ReactMethod
-    public void track(final String token, final String eventName, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void track(final String token, final boolean trackAutomaticEvents, final String eventName, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject eventProperties = ReactNativeHelper.reactToJSON(properties);
             AutomaticProperties.appendLibraryProperties(eventProperties);
@@ -130,8 +130,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void registerSuperProperties(final String token, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void registerSuperProperties(final String token, final boolean trackAutomaticEvents, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject superProperties = ReactNativeHelper.reactToJSON(properties);
             instance.registerSuperProperties(superProperties);
@@ -140,8 +140,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void registerSuperPropertiesOnce(final String token, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void registerSuperPropertiesOnce(final String token, final boolean trackAutomaticEvents, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject superProperties = ReactNativeHelper.reactToJSON(properties);
             instance.registerSuperPropertiesOnce(superProperties);
@@ -150,8 +150,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void unregisterSuperProperty(final String token, String superPropertyName, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void unregisterSuperProperty(final String token, final boolean trackAutomaticEvents, String superPropertyName, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.unregisterSuperProperty(superPropertyName);
             promise.resolve(null);
@@ -159,8 +159,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void union(final String token, String name, ReadableArray value, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void union(final String token, final boolean trackAutomaticEvents, String name, ReadableArray value, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONArray propertyValue = ReactNativeHelper.reactToJSON(value);
             instance.getPeople().union(name, propertyValue);
@@ -169,16 +169,16 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getSuperProperties(final String token, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void getSuperProperties(final String token, final boolean trackAutomaticEvents, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             promise.resolve(ReactNativeHelper.convertJsonToMap(instance.getSuperProperties()));
         }
     }
 
     @ReactMethod
-    public void clearSuperProperties(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void clearSuperProperties(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.clearSuperProperties();
             promise.resolve(null);
@@ -186,8 +186,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void alias(final String token, String alias, String original, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void alias(final String token, final boolean trackAutomaticEvents, String alias, String original, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.alias(alias, original);
             promise.resolve(null);
@@ -195,8 +195,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void reset(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void reset(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.reset();
             promise.resolve(null);
@@ -204,8 +204,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void flush(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void flush(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.flush();
             promise.resolve(null);
@@ -213,8 +213,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void timeEvent(final String token, final String eventName, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void timeEvent(final String token, final boolean trackAutomaticEvents, final String eventName, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.timeEvent(eventName);
             promise.resolve(null);
@@ -222,16 +222,16 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void eventElapsedTime(final String token, final String eventName, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void eventElapsedTime(final String token, final boolean trackAutomaticEvents, final String eventName, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             promise.resolve(instance.eventElapsedTime(eventName));
         }
     }
 
     @ReactMethod
-    public void set(final String token, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void set(final String token, final boolean trackAutomaticEvents, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject sendProperties = ReactNativeHelper.reactToJSON(properties);
             AutomaticProperties.appendLibraryProperties(sendProperties);
@@ -241,8 +241,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void unset(final String token, String propertyName, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void unset(final String token, final boolean trackAutomaticEvents, String propertyName, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getPeople().unset(propertyName);
             promise.resolve(null);
@@ -250,8 +250,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setOnce(final String token, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void setOnce(final String token, final boolean trackAutomaticEvents, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject sendProperties = ReactNativeHelper.reactToJSON(properties);
             AutomaticProperties.appendLibraryProperties(sendProperties);
@@ -261,8 +261,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void trackCharge(final String token, double charge, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void trackCharge(final String token, final boolean trackAutomaticEvents, double charge, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject transactionValue = ReactNativeHelper.reactToJSON(properties);
             instance.getPeople().trackCharge(charge, transactionValue);
@@ -271,8 +271,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void clearCharges(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void clearCharges(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getPeople().clearCharges();
             promise.resolve(null);
@@ -280,9 +280,9 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void increment(final String token, ReadableMap properties, Promise promise) {
+    public void increment(final String token, final boolean trackAutomaticEvents, ReadableMap properties, Promise promise) {
         Map incrementProperties = ReactNativeHelper.toMap(properties);
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getPeople().increment(incrementProperties);
             promise.resolve(null);
@@ -290,8 +290,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void append(final String token, String name, Dynamic value, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void append(final String token, final boolean trackAutomaticEvents, String name, Dynamic value, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getPeople().append(name, ReactNativeHelper.dynamicToObject(value));
             promise.resolve(null);
@@ -299,8 +299,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void deleteUser(final String token, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void deleteUser(final String token, final boolean trackAutomaticEvents, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getPeople().deleteUser();
             promise.resolve(null);
@@ -308,8 +308,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void remove(final String token, String name, Dynamic value, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void remove(final String token, final boolean trackAutomaticEvents, String name, Dynamic value, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getPeople().remove(name, ReactNativeHelper.dynamicToObject(value));
             promise.resolve(null);
@@ -317,8 +317,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void trackWithGroups(final String token, String eventName, ReadableMap properties, ReadableMap groups, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void trackWithGroups(final String token, final boolean trackAutomaticEvents, String eventName, ReadableMap properties, ReadableMap groups, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             Map eventProperties = ReactNativeHelper.toMap(properties);
             Map eventGroups = ReactNativeHelper.toMap(groups);
@@ -329,8 +329,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
 
 
     @ReactMethod
-    public void setGroup(final String token, String groupKey, Dynamic groupID, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void setGroup(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.setGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID));
             promise.resolve(null);
@@ -338,8 +338,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setGroups(final String token, String groupKey, ReadableArray groupIDs, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void setGroups(final String token, final boolean trackAutomaticEvents, String groupKey, ReadableArray groupIDs, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.setGroup(groupKey, Arrays.asList(ReactNativeHelper.toArray(groupIDs)));
             promise.resolve(null);
@@ -347,8 +347,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void addGroup(final String token, String groupKey, Dynamic groupID, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void addGroup(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.addGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID));
             promise.resolve(null);
@@ -356,8 +356,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void removeGroup(final String token, String groupKey, Dynamic groupID, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void removeGroup(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.removeGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID));
             promise.resolve(null);
@@ -365,8 +365,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void deleteGroup(final String token, String groupKey, Dynamic groupID, Promise promise) {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void deleteGroup(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID)).deleteGroup();
             promise.resolve(null);
@@ -374,8 +374,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void groupSetProperties(final String token, String groupKey, Dynamic groupID, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void groupSetProperties(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject sendProperties = ReactNativeHelper.reactToJSON(properties);
             instance.getGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID)).set(sendProperties);
@@ -384,8 +384,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void groupSetPropertyOnce(final String token, String groupKey, Dynamic groupID, ReadableMap properties, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void groupSetPropertyOnce(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONObject sendProperties = ReactNativeHelper.reactToJSON(properties);
             instance.getGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID)).setOnce(sendProperties);
@@ -394,8 +394,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void groupUnsetProperty(final String token, String groupKey, Dynamic groupID, String propertyName, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void groupUnsetProperty(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, String propertyName, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID)).unset(propertyName);
             promise.resolve(null);
@@ -403,8 +403,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void groupRemovePropertyValue(final String token, String groupKey, Dynamic groupID, String name, Dynamic value, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void groupRemovePropertyValue(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, String name, Dynamic value, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             instance.getGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID)).remove(name, ReactNativeHelper.dynamicToObject(value));
             promise.resolve(null);
@@ -412,8 +412,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void groupUnionProperty(final String token, String groupKey, Dynamic groupID, String name, ReadableArray values, Promise promise) throws JSONException {
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token);
+    public void groupUnionProperty(final String token, final boolean trackAutomaticEvents, String groupKey, Dynamic groupID, String name, ReadableArray values, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents);
         synchronized (instance) {
             JSONArray arrayValues = ReactNativeHelper.reactToJSON(values);
             instance.getGroup(groupKey, ReactNativeHelper.dynamicToObject(groupID)).union(name, arrayValues);

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -36,7 +36,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     public void initialize(String token, boolean trackAutomaticEvents, boolean optOutTrackingDefault, ReadableMap metadata, Promise promise) throws JSONException {
         JSONObject mixpanelProperties = ReactNativeHelper.reactToJSON(metadata);
         AutomaticProperties.setAutomaticProperties(mixpanelProperties);
-        MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents, optOutTrackingDefault, mixpanelProperties);
+        MixpanelAPI.getInstance(this.mReactContext, token, optOutTrackingDefault, mixpanelProperties, null, trackAutomaticEvents);
         promise.resolve(null);
     }
 

--- a/index.js
+++ b/index.js
@@ -53,13 +53,14 @@ export class Mixpanel {
     /**
      * Initializes Mixpanel
      *
+     * @param {boolean} Whether or not to automatically track common mobile events
      * @param {boolean} Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()
      * @param {object}  Optional A Map containing the key value pairs of the super properties to register
      *
      */
-    async init(optOutTrackingDefault = DEFAULT_OPT_OUT, superProperties = {}) {
+    async init(trackAutomaticEvents, optOutTrackingDefault = DEFAULT_OPT_OUT, superProperties = {}) {
         let metadata = Helper.getMetaData();
-        await MixpanelReactNative.initialize(this.token, optOutTrackingDefault, {...metadata, ...superProperties});
+        await MixpanelReactNative.initialize(this.token, trackAutomaticEvents, optOutTrackingDefault, {...metadata, ...superProperties});
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -42,25 +42,25 @@ const DEFAULT_OPT_OUT = false;
  */
 export class Mixpanel {
 
-    constructor(token) {
+    constructor(token, trackAutomaticEvents) {
         if (!StringHelper.isValid(token)) {
             StringHelper.raiseError(PARAMS.TOKEN);
         }
         this.token = token;
+        this.trackAutomaticEvents = trackAutomaticEvents;
         this.people = new People(this.token);
     }
 
     /**
      * Initializes Mixpanel
      *
-     * @param {boolean} trackAutomaticEvents Whether or not to automatically track common mobile events
      * @param {boolean} optOutTrackingDefault Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()
      * @param {object} superProperties  Optional A Map containing the key value pairs of the super properties to register
      *
      */
     async init(trackAutomaticEvents, optOutTrackingDefault = DEFAULT_OPT_OUT, superProperties = {}) {
         let metadata = Helper.getMetaData();
-        await MixpanelReactNative.initialize(this.token, trackAutomaticEvents, optOutTrackingDefault, {...metadata, ...superProperties});
+        await MixpanelReactNative.initialize(this.token, this.trackAutomaticEvents, optOutTrackingDefault, {...metadata, ...superProperties});
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ export class Mixpanel {
     static async init(token, trackAutomaticEvents, optOutTrackingDefault = DEFAULT_OPT_OUT) {
         let metadata = Helper.getMetaData();
         await MixpanelReactNative.initialize(token, trackAutomaticEvents, optOutTrackingDefault, metadata);
-        return new Mixpanel(token);
+        return new Mixpanel(token, trackAutomaticEvents);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ export class Mixpanel {
     /**
      * Initializes Mixpanel
      *
-     * @param {boolean} Whether or not to automatically track common mobile events
-     * @param {boolean} Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()
-     * @param {object}  Optional A Map containing the key value pairs of the super properties to register
+     * @param {boolean} trackAutomaticEvents Whether or not to automatically track common mobile events
+     * @param {boolean} optOutTrackingDefault Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()
+     * @param {object} superProperties  Optional A Map containing the key value pairs of the super properties to register
      *
      */
     async init(trackAutomaticEvents, optOutTrackingDefault = DEFAULT_OPT_OUT, superProperties = {}) {
@@ -74,12 +74,13 @@ export class Mixpanel {
      * Initializes Mixpanel and return an instance of Mixpanel the given project token.
      *
      * @param {string} token your project token.
+     * @param {boolean} trackAutomaticEvents Whether or not to automatically track common mobile events
      * @param {boolean} Optional Whether or not Mixpanel can start tracking by default. See optOutTracking()
      *
      */
-    static async init(token, optOutTrackingDefault = DEFAULT_OPT_OUT) {
+    static async init(token, trackAutomaticEvents, optOutTrackingDefault = DEFAULT_OPT_OUT) {
         let metadata = Helper.getMetaData();
-        await MixpanelReactNative.initialize(token, optOutTrackingDefault, metadata);
+        await MixpanelReactNative.initialize(token, trackAutomaticEvents, optOutTrackingDefault, metadata);
         return new Mixpanel(token);
     }
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ export class Mixpanel {
      * @param {object} superProperties  Optional A Map containing the key value pairs of the super properties to register
      *
      */
-    async init(trackAutomaticEvents, optOutTrackingDefault = DEFAULT_OPT_OUT, superProperties = {}) {
+    async init(optOutTrackingDefault = DEFAULT_OPT_OUT, superProperties = {}) {
         let metadata = Helper.getMetaData();
         await MixpanelReactNative.initialize(this.token, this.trackAutomaticEvents, optOutTrackingDefault, {...metadata, ...superProperties});
     }

--- a/index.js
+++ b/index.js
@@ -46,6 +46,9 @@ export class Mixpanel {
         if (!StringHelper.isValid(token)) {
             StringHelper.raiseError(PARAMS.TOKEN);
         }
+        if (trackAutomaticEvents == null) {
+            throw new Error(`trackAutomaticEvents is undefined`);
+        }
         this.token = token;
         this.trackAutomaticEvents = trackAutomaticEvents;
         this.people = new People(this.token);

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -13,12 +13,13 @@ open class MixpanelReactNative: NSObject {
 
     @objc
     func initialize(_ token: String,
+                    trackAutomaticEvents: Bool,
                     optOutTrackingByDefault: Bool = false,
                     properties: [String: Any],
                     resolver resolve: RCTPromiseResolveBlock,
                     rejecter reject: RCTPromiseRejectBlock) -> Void {
         AutomaticProperties.setAutomaticProperties(properties)
-        Mixpanel.initialize(token: token, flushInterval: Constants.DEFAULT_FLUSH_INTERVAL,
+        Mixpanel.initialize(token: token, trackAutomaticEvents: trackAutomaticEvents, flushInterval: Constants.DEFAULT_FLUSH_INTERVAL,
                             instanceName: token, optOutTrackingByDefault: optOutTrackingByDefault,
                             superProperties: MixpanelTypeHandler.processProperties(properties: properties, includeLibInfo: true))
         resolve(true)

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -440,11 +440,7 @@ open class MixpanelReactNative: NSObject {
         if token.isEmpty {
             return nil
         }
-        var instance = Mixpanel.getInstance(name: token)
-        if instance == nil {
-            instance = Mixpanel.initialize(token: token, instanceName: token)
-        }
-        return instance
+        return Mixpanel.getInstance(name: token)
     }
     
 }


### PR DESCRIPTION
This PR bumps to underlying native SDK version to their new major versions which drop support for Decide and make `trackAutomaticEvents` a required parameter.