### PR TITLE
use semaphore to prevent concurrent access to properties object

### DIFF
--- a/ios/AutomaticProperties.swift
+++ b/ios/AutomaticProperties.swift
@@ -3,10 +3,14 @@ import Mixpanel
 
 class AutomaticProperties {
     static var peopleProperties: Dictionary<String, MixpanelType> = [:];
+    private static let semaphore = DispatchSemaphore(value: 0)
+    
     
     static func setAutomaticProperties(_ properties: [String: Any]) {
-        for (key,value) in properties ?? [:]  {
+        semaphore.wait()
+        for (key,value) in properties {
             peopleProperties[key] = MixpanelTypeHandler.mixpanelTypeValue(value)
         }
+        semaphore.signal()
     }
 }


### PR DESCRIPTION
Attempt to fix https://github.com/mixpanel/mixpanel-react-native/issues/179