### PR TITLE
Remove semaphores, copy properties, use .merging, don't includeLibInfo in init

### DIFF
--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }  
   
   s.dependency "React-Core"
-  s.dependency "Mixpanel-swift", '4.1.0'
+  s.dependency "Mixpanel-swift", '4.1.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:7.3.0'
+    implementation 'com.mixpanel.android:mixpanel-android:7.3.1'
 }

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -35,6 +35,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void initialize(String token, boolean trackAutomaticEvents, boolean optOutTrackingDefault, ReadableMap metadata, String serverURL, Promise promise) throws JSONException {
         JSONObject mixpanelProperties = ReactNativeHelper.reactToJSON(metadata);
+        AutomaticProperties.setAutomaticProperties(mixpanelProperties);
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, optOutTrackingDefault, mixpanelProperties, null, trackAutomaticEvents);
         instance.setServerURL(serverURL);
         promise.resolve(null);

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -35,7 +35,6 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void initialize(String token, boolean trackAutomaticEvents, boolean optOutTrackingDefault, ReadableMap metadata, String serverURL, Promise promise) throws JSONException {
         JSONObject mixpanelProperties = ReactNativeHelper.reactToJSON(metadata);
-        AutomaticProperties.setAutomaticProperties(mixpanelProperties);
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, optOutTrackingDefault, mixpanelProperties, null, trackAutomaticEvents);
         instance.setServerURL(serverURL);
         promise.resolve(null);

--- a/ios/AutomaticProperties.swift
+++ b/ios/AutomaticProperties.swift
@@ -3,14 +3,10 @@ import Mixpanel
 
 class AutomaticProperties {
     static var peopleProperties: Dictionary<String, MixpanelType> = [:];
-    private static let semaphore = DispatchSemaphore(value: 0)
-    
     
     static func setAutomaticProperties(_ properties: [String: Any]) {
-        semaphore.wait()
         for (key,value) in properties {
             peopleProperties[key] = MixpanelTypeHandler.mixpanelTypeValue(value)
         }
-        semaphore.signal()
     }
 }

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -21,7 +21,7 @@ open class MixpanelReactNative: NSObject {
                     rejecter reject: RCTPromiseRejectBlock) -> Void {
         Mixpanel.initialize(token: token, trackAutomaticEvents: trackAutomaticEvents, flushInterval: Constants.DEFAULT_FLUSH_INTERVAL,
                             instanceName: token, optOutTrackingByDefault: optOutTrackingByDefault,
-                            superProperties: MixpanelTypeHandler.processProperties(properties: properties, includeLibInfo: true),
+                            superProperties: MixpanelTypeHandler.processProperties(properties: properties),
                             serverURL: serverURL)
         resolve(true)
     }

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -19,9 +19,12 @@ open class MixpanelReactNative: NSObject {
                     serverURL: String,
                     resolver resolve: RCTPromiseResolveBlock,
                     rejecter reject: RCTPromiseRejectBlock) -> Void {
+        let autoProps = properties // copy
+        AutomaticProperties.setAutomaticProperties(autoProps)
+        let propsProcessed = MixpanelTypeHandler.processProperties(properties: properties)
         Mixpanel.initialize(token: token, trackAutomaticEvents: trackAutomaticEvents, flushInterval: Constants.DEFAULT_FLUSH_INTERVAL,
                             instanceName: token, optOutTrackingByDefault: optOutTrackingByDefault,
-                            superProperties: MixpanelTypeHandler.processProperties(properties: properties),
+                            superProperties: propsProcessed,
                             serverURL: serverURL)
         resolve(true)
     }
@@ -100,7 +103,7 @@ open class MixpanelReactNative: NSObject {
                resolver resolve: RCTPromiseResolveBlock,
                rejecter reject: RCTPromiseRejectBlock) -> Void {
         let instance = MixpanelReactNative.getMixpanelInstance(token)
-        let mpProperties = MixpanelTypeHandler.processProperties(properties: properties, includeLibInfo: true)
+        let mpProperties = MixpanelTypeHandler.processProperties(properties: properties)
         instance?.track(event: event, properties: mpProperties)
         resolve(nil)
     }
@@ -317,7 +320,7 @@ open class MixpanelReactNative: NSObject {
                          resolver resolve: RCTPromiseResolveBlock,
                          rejecter reject: RCTPromiseRejectBlock) -> Void {
         let instance = MixpanelReactNative.getMixpanelInstance(token)
-        let mpProperties = MixpanelTypeHandler.processProperties(properties: properties, includeLibInfo: true)
+        let mpProperties = MixpanelTypeHandler.processProperties(properties: properties)
         var mpGroups = Dictionary<String, MixpanelType>()
         for (key,value) in groups ?? [:] {
             mpGroups[key] = MixpanelTypeHandler.mixpanelTypeValue(value)

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -19,7 +19,6 @@ open class MixpanelReactNative: NSObject {
                     serverURL: String,
                     resolver resolve: RCTPromiseResolveBlock,
                     rejecter reject: RCTPromiseRejectBlock) -> Void {
-        AutomaticProperties.setAutomaticProperties(properties)
         Mixpanel.initialize(token: token, trackAutomaticEvents: trackAutomaticEvents, flushInterval: Constants.DEFAULT_FLUSH_INTERVAL,
                             instanceName: token, optOutTrackingByDefault: optOutTrackingByDefault,
                             superProperties: MixpanelTypeHandler.processProperties(properties: properties, includeLibInfo: true),

--- a/ios/MixpanelTypeHandler.swift
+++ b/ios/MixpanelTypeHandler.swift
@@ -78,7 +78,7 @@
             mpProperties[key] = mixpanelTypeValue(value)
         }
         if (includeLibInfo) {
-            return mpProperties.merging(dict: AutomaticProperties.peopleProperties) { (_, new) in new }
+            return mpProperties.merging(AutomaticProperties.peopleProperties) { (_, new) in new }
         }
         return mpProperties
     }

--- a/ios/MixpanelTypeHandler.swift
+++ b/ios/MixpanelTypeHandler.swift
@@ -78,16 +78,8 @@
             mpProperties[key] = mixpanelTypeValue(value)
         }
         if (includeLibInfo) {
-            mpProperties.merge(dict: AutomaticProperties.peopleProperties)
+            return mpProperties.merging(dict: AutomaticProperties.peopleProperties) { (_, new) in new }
         }
         return mpProperties
-    }
- }
- 
- extension Dictionary {
-    mutating func merge(dict: [Key: Value]){
-        for (k, v) in dict {
-            updateValue(v, forKey: k)
-        }
     }
  }


### PR DESCRIPTION
The `properties` object passed to `initialize()` contains both the lib metadata (i.e. `mp_lib` and `$lib_version`) and the user specified super properties: https://github.com/mixpanel/mixpanel-react-native/blob/master/index.js#L67

That object is then passed to the native initialize method as the `superProperties` param to be registered prior to all event tracking (so there is no need to `includeLibInfo` when we process the properties: https://github.com/mixpanel/mixpanel-react-native/blob/master/ios/MixpanelReactNative.swift#L25

Additionally, make a copy of the `properties` dictionary to be passed to `setAutomaticProperties`. So that it is not the same value that is passed to `processProperties` and use native `.merging()` method to create a new dictionary instead of using custom mutating `merge` function.

Because the lib properties are registered as super properties upon initialization, we do not need to `includeLibInfo` when we call `track` or `trackWithGroups`, only people calls will need them.

