### PR TITLE
RN 73 support for Android with AGP 8 required

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,13 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 33
     buildToolsVersion "30.0.3"
+    
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace "com.mixpanel.reactnative"
+    }
+
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 33


### PR DESCRIPTION
By setting a namespace in `android/build.gradle`.

Ref: https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1598892444