### PR TITLE
add api: setFlushBatchSize

### DIFF
--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }  
   
   s.dependency "React-Core"
-  s.dependency "Mixpanel-swift", '4.1.3'
+  s.dependency "Mixpanel-swift", '4.2.0'
 end

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -39,7 +39,7 @@ test(`it calls MixpanelReactNative setUseIpAddressForGeolocation`, async () => {
 test(`it calls MixpanelReactNative setFlushBatchSize`, async () => {
   const mixpanel = await Mixpanel.init("token", true);
   mixpanel.setFlushBatchSize(20);
-  expect(NativeModules.MixpanelReactNative.setFlushBatchSize).toBeCalledWith("token", true);
+  expect(NativeModules.MixpanelReactNative.setFlushBatchSize).toBeCalledWith("token", 20);
 });
 
 test(`it calls MixpanelReactNative hasOptedOutTracking`, async () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -36,6 +36,12 @@ test(`it calls MixpanelReactNative setUseIpAddressForGeolocation`, async () => {
   expect(NativeModules.MixpanelReactNative.setUseIpAddressForGeolocation).toBeCalledWith("token", true);
 });
 
+test(`it calls MixpanelReactNative setFlushBatchSize`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  mixpanel.setFlushBatchSize(20);
+  expect(NativeModules.MixpanelReactNative.setFlushBatchSize).toBeCalledWith("token", true);
+});
+
 test(`it calls MixpanelReactNative hasOptedOutTracking`, async () => {
   const mixpanel = await Mixpanel.init("token", true);
   mixpanel.hasOptedOutTracking();

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -22,6 +22,7 @@ jest.doMock('react-native', () => {
           setLoggingEnabled: jest.fn(),
           setFlushOnBackground: jest.fn(),
           setUseIpAddressForGeolocation: jest.fn(),
+          setFlushBatchSize: jest.fn(),
           hasOptedOutTracking: jest.fn(),
           optInTracking: jest.fn(),
           optOutTracking: jest.fn(),

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:7.3.1'
+    implementation 'com.mixpanel.android:mixpanel-android:7.3.2'
 }

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -55,7 +55,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setUseIpAddressForGeolocation(final String token, boolean useIpAddressForGeolocation, Promise promise) throws JSONException {
+    public void setUseIpAddressForGeolocation(final String token, boolean useIpAddressForGeolocation, Promise promise)
+            throws JSONException {
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
         if (instance == null) {
             promise.reject("Instance Error", "Failed to get Mixpanel instance");
@@ -63,6 +64,19 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         }
         synchronized (instance) {
             instance.setUseIpAddressForGeolocation(useIpAddressForGeolocation);
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
+    public void setFlushBatchSize(final String token, Integer flushBatchSize, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
+        if (instance == null) {
+            promise.reject("Instance Error", "Failed to get Mixpanel instance");
+            return;
+        }
+        synchronized (instance) {
+            instance.setFlushBatchSize(flushBatchSize);
             promise.resolve(null);
         }
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,8 @@ export class Mixpanel {
     setServerURL(serverURL: string): void;
     setLoggingEnabled(loggingEnabled: boolean): void;
     setFlushOnBackground(flushOnBackground: boolean): void;
-
     setUseIpAddressForGeolocation(useIpAddressForGeolocation: boolean): void;
+    setFlushBatchSize(flushBatchSize: number): void;
     hasOptedOutTracking(): Promise<boolean>;
     optInTracking(): void;
     optOutTracking(): void;

--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ export class Mixpanel {
         MixpanelReactNative.setFlushBatchSize(this.token, flushBatchSize);
     }
 
+
     /**
      * Will return true if the user has opted out from tracking.
      *

--- a/index.js
+++ b/index.js
@@ -140,6 +140,18 @@ export class Mixpanel {
     setUseIpAddressForGeolocation(useIpAddressForGeolocation) {
         MixpanelReactNative.setUseIpAddressForGeolocation(this.token, useIpAddressForGeolocation);
     }
+    
+    /**
+     * Set the number of events sent in a single network request to the Mixpanel server.
+     * By configuring this value, you can optimize network usage and manage the frequency of communication between the client and the server. The maximum size is 50; any value over 50 will default to 50.
+     *
+     * @param {integer} flushBatchSize whether to automatically send the client IP Address.
+     * Defaults to true.
+     *
+     */
+    setFlushBatchSize(flushBatchSize) {
+        MixpanelReactNative.setFlushBatchSize(this.token, flushBatchSize);
+    }
 
     /**
      * Will return true if the user has opted out from tracking.

--- a/ios/MixpanelReactNative.m
+++ b/ios/MixpanelReactNative.m
@@ -16,6 +16,8 @@ RCT_EXTERN_METHOD(setFlushOnBackground:(NSString *)token flushOnBackground:(BOOL
 
 RCT_EXTERN_METHOD(setUseIpAddressForGeolocation:(NSString *)token useIpAddressForGeolocation:(BOOL)useIpAddressForGeolocation resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setFlushBatchSize:(NSString *)token flushBatchSize:(NSInteger)flushBatchSize resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 // MARK: - Opting Users Out of Tracking
 
 RCT_EXTERN_METHOD(optOutTracking:(NSString *)token resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -60,6 +60,16 @@ open class MixpanelReactNative: NSObject {
     }
 
     @objc
+    func setFlushBatchSize(_ token: String,
+                    flushBatchSize: Int,
+                    resolver resolve: RCTPromiseResolveBlock,
+                    rejecter reject: RCTPromiseRejectBlock) -> Void {
+        let instance = MixpanelReactNative.getMixpanelInstance(token)
+        instance?.flushBatchSize = flushBatchSize
+        resolve(nil)
+    }
+
+    @objc
     func setUseIpAddressForGeolocation(_ token: String,
                     useIpAddressForGeolocation: Bool,
                     resolver resolve: RCTPromiseResolveBlock,


### PR DESCRIPTION
add a new api
```
    /**
     * Set the number of events sent in a single network request to the Mixpanel server.
     * By configuring this value, you can optimize network usage and manage the frequency of communication between the client and the server. The maximum size is 50; any value over 50 will default to 50.
     *
     * @param {integer} flushBatchSize whether to automatically send the client IP Address.
     * Defaults to true.
     *
     */
    setFlushBatchSize(flushBatchSize) {
        MixpanelReactNative.setFlushBatchSize(this.token, flushBatchSize);
    }
```