### PR TITLE
fix storage adapter info being logged on every app launch

### DIFF
--- a/javascript/mixpanel-persistent.js
+++ b/javascript/mixpanel-persistent.js
@@ -50,8 +50,6 @@ export class MixpanelPersistent {
   }
 
   async loadDeviceId(token) {
-    console.info("storageAdapter", this.storageAdapter);
-    console.info("storageAdapter get item", this.storageAdapter.getItem());
     await this.storageAdapter
       .getItem(getDeviceIdKey(token))
       .then((deviceId) => {


### PR DESCRIPTION
Fixes 

```
 INFO  storageAdapter {"storage": {"default": {"clear": [Function clear], "flushGetRequests": [Function flushGetRequests], "getAllKeys": [Function getAllKeys], "getItem": [Function getItem], "mergeItem": [Function mergeItem], "multiGet": [Function multiGet], "multiMerge": [Function multiMerge], "multiRemove": [Function multiRemove], "multiSet": [Function multiSet], "removeItem": [Function removeItem], "setItem": [Function setItem]}, "useAsyncStorage": [Function useAsyncStorage]}}
 INFO  storageAdapter get item {"_h": 0, "_i": 1, "_j": null, "_k": null}
```

being logged into console on every app launch.