### PR TITLE
fix: fix adapter storage jest setup

### DIFF
--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -3,9 +3,9 @@ import * as ReactNative from "react-native";
 jest.mock("mixpanel-react-native/javascript/mixpanel-storage", () => {
   return {
     AsyncStorageAdapter: jest.fn().mockImplementation(() => ({
-      getItem: jest.fn(),
-      setItem: jest.fn(),
-      removeItem: jest.fn(),
+      getItem: jest.fn().mockResolvedValue(null),
+      setItem: jest.fn().mockResolvedValue(undefined),
+      removeItem: jest.fn().mockResolvedValue(undefined),
     })),
   };
 });


### PR DESCRIPTION
This pr contains the fix for the following error during the tests runtime:

```
/Users/me/project/node_modules/mixpanel-react-native/javascript/mixpanel-persistent.js:45
        yield this.storageAdapter.getItem((0, _mixpanelConstants.getDeviceIdKey)(token)).then(function (deviceId) {
        
        TypeError: Cannot read properties of undefined (reading 'then')
```
