### PR TITLE
Require only the used subset of `AsnycStorage` as custom storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To enable this feature,
 ```
 npm install @react-native-async-storage/async-storage
 ```
-When JavaScript mode is enabled, Mixpanel utilizes [AsyncStorage](https://reactnative.dev/docs/asyncstorage) to persist data. If you prefer not to use it, or if AsyncStorage is unavailable in your target environment, you can import or define a different storage class. However, it must follow the same interface as [AsyncStorage](https://reactnative.dev/docs/asyncstorage) The following example demonstrates how to use a custom storage solution:
+When JavaScript mode is enabled, Mixpanel utilizes [AsyncStorage](https://react-native-async-storage.github.io/async-storage/) to persist data. If you prefer not to use it, or if AsyncStorage is unavailable in your target environment, you can import or define a different storage class. However, it must follow a subset (see: [`MixpanelAsyncStorage`](index.d.ts)) of the same interface as [AsyncStorage](https://react-native-async-storage.github.io/async-storage/) The following example demonstrates how to use a custom storage solution:
 
 ```
 // Optional: if you do not want to use the default AsyncStorage

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,18 @@
 type MixpanelType = any;
 type MixpanelProperties = {[key: string]: MixpanelType};
 
+export type MixpanelAsyncStorage = {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
 export class Mixpanel {
   constructor(
     token: string,
     trackAutomaticEvents: boolean,
     useNative?: boolean,
-    storage?: any
+    storage?: MixpanelAsyncStorage
   );
   static init(
     token: string,


### PR DESCRIPTION
According to the implementation in `javascript/mixpanel-storage.js`, only a subset of the `AsyncStorage` interface is actually used by Mixpanel.

Not having this interface explicitly defined is problematic, because it requires devs to assume that Mixpanel may use a larger subset of the interface at any time. Devs would need to either implement the full interface, or risk breaking changes if Mixpanel's usage changes. Additionally, the types should reflect the required interface, so it's obvious that they have appropriately implemented it.

This PR does two main things:

1. Defines that interface in the official types. So devs can be sure they are implementing the full interface required by Mixpanel
2. References this interface in the docs

Additionally, it links to the correct `AsyncStorage` reference, rather than the one that has been long removed from React Native.