### PR TITLE
fix(types): make `useNative` optional boolean instead of literal types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,11 +9,11 @@ export type MixpanelAsyncStorage = {
 
 export class Mixpanel {
   constructor(token: string, trackAutoMaticEvents: boolean);
-  constructor(token: string, trackAutoMaticEvents: boolean, useNative: true);
+  constructor(token: string, trackAutoMaticEvents: boolean, useNative?: boolean);
   constructor(
     token: string,
     trackAutomaticEvents: boolean,
-    useNative: false,
+    useNative?: boolean,
     storage?: MixpanelAsyncStorage
   );
   static init(


### PR DESCRIPTION
### Problem
Currently, if you want to use custom storage, you’re forced to set `useNative: false` this causes the SDK to run in JavaScript mode which disables native features (e.g, Legacy Automatically Tracked Events)

### Solution
Update the type definition of `useNative` from literal types to an optional boolean