### PR TITLE
Pass server URL to native Mixpanel android instance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:8.2.4'
+    implementation 'com.mixpanel.android:mixpanel-android:8.2.7'
 }

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -60,6 +60,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         MixpanelOptions.Builder optionsBuilder = new MixpanelOptions.Builder()
             .optOutTrackingDefault(optOutTrackingDefault)
             .superProperties(mixpanelProperties)
+            .serverURL(serverURL)
             .featureFlagsEnabled(featureFlagsEnabled);
 
         if (featureFlagsContext != null) {
@@ -69,7 +70,6 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         MixpanelOptions options = optionsBuilder.build();
 
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents, options);
-        instance.setServerURL(serverURL);
         if (useGzipCompression) {
             instance.setShouldGzipRequestPayload(true);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-react-native",
-  "version": "3.2.0-beta.3",
+  "version": "3.2.0-beta.4",
   "description": "Official React Native Tracking Library for Mixpanel Analytics",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Flags provider needs the server URL set prior to instance initialization. mixpanel-android 8.2.7+ got support for serverURL getting passed into the builder options so this change syncs it up in react-native