### PR TITLE
[DEV-72] chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [18.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -34,21 +34,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947  # v4
 
       - name: Install dependencies
         run: |
@@ -67,7 +67,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         id: avd-cache
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a  # v2
         env:
           GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false
           JAVA_OPTS: -Xmx4096m
@@ -93,7 +93,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run Android Tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a  # v2
         env:
           GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false
           JAVA_OPTS: -Xmx4096m
@@ -119,9 +119,9 @@ jobs:
         node-version: [18.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,9 +12,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8  # v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # v1
       - name: "Update Release CHANGELOG"
         id: update-release-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
+        uses: heinrichreimer/github-changelog-generator-action@854576bb5274851427527d8199fba0061552dff5  # v2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           onlyLastTag: true
@@ -38,14 +38,14 @@ jobs:
           git config user.email "zihe.jia@mixpanel.com"
           git commit -m "Update CHANGELOG"
       - name: Push CHANGELOG changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
           force: true
       - name: "Prepare for the Github Release"
         id: generate-release-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
+        uses: heinrichreimer/github-changelog-generator-action@854576bb5274851427527d8199fba0061552dff5  # v2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: "output.md"
@@ -63,7 +63,7 @@ jobs:
           author: false
           verbose: true
       - name: "🚀 Create GitHub Release"
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
Pin all GitHub Actions workflow steps to immutable full commit SHAs instead of mutable tags or branches.

## Why
Mutable tags can be moved after the fact, making it possible for a supply-chain attack to inject malicious code into CI. Pinning to a commit SHA ensures the exact version of an action is used, and the original tag is preserved as an inline comment for readability.

## Verification
Review the diff — all `uses:` lines with third-party actions should now reference a 40-character commit SHA with the original tag as an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: https://linear.app/mixpanel/issue/DEV-72/pin-all-github-actions-to-commit-shas