### PR TITLE
chore: update mixpanel-ios SDK to 6.4.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ npm test
 - `uuid@3.3.2` - UUID generation
 
 ### Native SDK Dependencies
-- iOS: `Mixpanel-swift@6.4.0`
+- iOS: `Mixpanel-swift@6.4.1`
 - Android: `mixpanel-android@8.7.0`
 
 ## Sample Apps

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ npm test
 - `uuid@3.3.2` - UUID generation
 
 ### Native SDK Dependencies
-- iOS: `Mixpanel-swift@5.1.0`
+- iOS: `Mixpanel-swift@6.4.0`
 - Android: `mixpanel-android@8.2.0`
 
 ## Sample Apps

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -133,6 +133,8 @@ jobs:
         working-directory: ./Samples/MixpanelExample/ios
         run: |
           rm -f Podfile.lock
+          rm -rf ~/Library/Caches/CocoaPods
+          pod cache clean --all
           pod install --repo-update
       - name: Test iOS
         working-directory: ./Samples/MixpanelExample

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -133,8 +133,6 @@ jobs:
         working-directory: ./Samples/MixpanelExample/ios
         run: |
           rm -f Podfile.lock
-          rm -rf ~/Library/Caches/CocoaPods
-          pod cache clean --all
           pod install --repo-update
       - name: Test iOS
         working-directory: ./Samples/MixpanelExample

--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
-  s.dependency "Mixpanel-swift", '5.2.0'
+  s.dependency "Mixpanel-swift", '6.4.0'
 end

--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
-  s.dependency "Mixpanel-swift", '6.4.0'
+  s.dependency "Mixpanel-swift", '6.4.1'
 end


### PR DESCRIPTION
## Summary
- Updates Mixpanel-swift iOS SDK dependency from 5.2.0 to 6.4.0

## Changes
- `MixpanelReactNative.podspec`: Updated `Mixpanel-swift` dependency version

## New features in Mixpanel-swift 6.4.0
- Feature Flag persistence
- Runtime event targeting support for feature flags
- Extended automatic event tracking to macOS
- Database file-protection improvements
- Various bug fixes and stability improvements

## Breaking Changes
- None for iOS (tvOS minimum deployment target bumped from 11.0 to 12.0 in v6.0.0)

## Test Plan
- [x] Tested on iOS simulator (iPhone 16 Pro, iOS 18.5)
- [x] Tested on Android emulator (Pixel 6, API 35)
- [x] Verified events are tracked successfully in Mixpanel dashboard