### PR TITLE
chore(all): set `yes=false` in .npmrc to prevent npx auto-install (DEV-376)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 # Prevent supply chain attacks
 min-release-age=7
+# Stop `npx` from silently downloading packages not in node_modules.
+# Equivalent to passing `--no` to every `npx` invocation.
+yes=false


### PR DESCRIPTION
## Summary

Adds `yes=false` to the repo's `.npmrc`. Equivalent to always passing `--no` to `npx`, causing it to error out instead of silently downloading packages that aren't already in `node_modules`.

## Context

Tracked under [DEV-376](https://linear.app/mixpanel/issue/DEV-376).

## Test plan

- [ ] CI is green
- [ ] Any legitimate `npx` usage in scripts/CI still works (should already have the package installed via `npm ci`)
