### PR TITLE
Implement flags persistence, reset on reload, and web parity & bugfixes

### DIFF
--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
-  s.dependency "Mixpanel-swift", '5.1.3'
+  s.dependency "Mixpanel-swift", '6.4.0'
 end

--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
-  s.dependency "Mixpanel-swift", '6.4.0'
+  s.dependency "Mixpanel-swift", '6.5.0'
 end

--- a/__tests__/flags-concurrency.test.js
+++ b/__tests__/flags-concurrency.test.js
@@ -61,7 +61,7 @@ describe("Feature Flags - Concurrency", () => {
       expect(callCount).toBe(1);
       resolvers[0]();
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await mixpanel.flags.whenReady();
+      await mixpanel.flags.loadFlags();
 
       callCount = 0;
       resolvers = [];
@@ -170,7 +170,7 @@ describe("Feature Flags - Concurrency", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await mixpanel.flags.whenReady();
+      await mixpanel.flags.loadFlags();
       const fetchesAfterInit = fetchCallCount;
 
       // Update context multiple times concurrently. Each call mutates the
@@ -278,7 +278,7 @@ describe("Feature Flags - Concurrency", () => {
       await new Promise((r) => setTimeout(r, 0));
       resolvers[0]();
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await mixpanel.flags.whenReady();
+      await mixpanel.flags.loadFlags();
       resolveCount = 0;
       resolvers = [];
 
@@ -360,7 +360,7 @@ describe("Feature Flags - Concurrency", () => {
       await new Promise((r) => setTimeout(r, 0));
       if (resolvers[0]) resolvers[0]();
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await mixpanel.flags.whenReady();
+      await mixpanel.flags.loadFlags();
       callCount = 0;
       resolvers = [];
 

--- a/__tests__/flags-concurrency.test.js
+++ b/__tests__/flags-concurrency.test.js
@@ -172,15 +172,18 @@ describe("Feature Flags - Concurrency", () => {
       await mixpanel.flags.whenReady();
       const fetchesAfterInit = fetchCallCount;
 
-      // Update context multiple times concurrently — concurrent calls share the
-      // in-flight fetch, so all three settle against the same network call.
+      // Update context multiple times concurrently. Each call mutates the
+      // context, invalidates any in-flight fetch, and starts a fresh fetch
+      // under the just-updated context — otherwise the second and third
+      // callers would await the first fetch (built with a stale context)
+      // and silently receive flags for the wrong targeting.
       const update1 = mixpanel.flags.updateContext({ plan: "free" });
       const update2 = mixpanel.flags.updateContext({ plan: "premium" });
       const update3 = mixpanel.flags.updateContext({ plan: "enterprise" });
 
       await Promise.all([update1, update2, update3]);
 
-      expect(fetchCallCount).toBe(fetchesAfterInit + 1);
+      expect(fetchCallCount).toBe(fetchesAfterInit + 3);
       expect(mixpanel.flags.areFlagsReady()).toBe(true);
     });
 

--- a/__tests__/flags-concurrency.test.js
+++ b/__tests__/flags-concurrency.test.js
@@ -30,8 +30,7 @@ describe("Feature Flags - Concurrency", () => {
   });
 
   describe("Concurrent Loading", () => {
-    it("should handle multiple simultaneous loadFlags() calls", async () => {
-      // Don't use fake timers for this test as it can cause issues
+    it("should dedupe simultaneous loadFlags() calls into one fetch", async () => {
       let resolvers = [];
       let callCount = 0;
 
@@ -53,18 +52,27 @@ describe("Feature Flags - Concurrency", () => {
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
 
-      // Start multiple loads simultaneously
+      // Force materialization of the flags lazy getter, then settle the init
+      // fetch (the one triggered by jsFlags.init()).
+      void mixpanel.flags;
+      await new Promise((r) => setTimeout(r, 0));
+      expect(callCount).toBe(1);
+      resolvers[0]();
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await mixpanel.flags.whenReady();
+
+      callCount = 0;
+      resolvers = [];
+
       const load1 = mixpanel.flags.loadFlags();
       const load2 = mixpanel.flags.loadFlags();
       const load3 = mixpanel.flags.loadFlags();
 
-      // All three should trigger network requests (no deduplication currently)
-      expect(callCount).toBe(3);
+      expect(callCount).toBe(1);
 
-      // Resolve all loads
-      resolvers.forEach(resolve => resolve && resolve());
+      resolvers[0]();
       await Promise.all([load1, load2, load3]);
 
       expect(mixpanel.flags.areFlagsReady()).toBe(true);
@@ -114,7 +122,7 @@ describe("Feature Flags - Concurrency", () => {
     });
 
     it("should trigger its own load if needed when using async read", async () => {
-      global.fetch.mockResolvedValueOnce({
+      global.fetch.mockResolvedValue({
         status: 200,
         json: () => Promise.resolve({
           flags: {
@@ -129,10 +137,8 @@ describe("Feature Flags - Concurrency", () => {
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
 
-      // Don't load flags initially - let async read trigger it
-      expect(mixpanel.flags.areFlagsReady()).toBe(false);
-
-      // Async read should trigger load
+      // Async read serves whatever the init-triggered fetch populated, or
+      // re-triggers one if the memory isn't usable.
       const variant = await mixpanel.flags.getVariant("auto-load", "fallback");
 
       expect(global.fetch).toHaveBeenCalled();
@@ -161,22 +167,20 @@ describe("Feature Flags - Concurrency", () => {
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await mixpanel.flags.whenReady();
+      const fetchesAfterInit = fetchCallCount;
 
-      // Load initial flags
-      await mixpanel.flags.loadFlags();
-      expect(fetchCallCount).toBe(1);
-
-      // Update context multiple times concurrently
+      // Update context multiple times concurrently — concurrent calls share the
+      // in-flight fetch, so all three settle against the same network call.
       const update1 = mixpanel.flags.updateContext({ plan: "free" });
       const update2 = mixpanel.flags.updateContext({ plan: "premium" });
       const update3 = mixpanel.flags.updateContext({ plan: "enterprise" });
 
       await Promise.all([update1, update2, update3]);
 
-      // Each update should trigger a new load
-      expect(fetchCallCount).toBe(4); // Initial + 3 updates
-
-      // Flags should be ready after all updates
+      expect(fetchCallCount).toBe(fetchesAfterInit + 1);
       expect(mixpanel.flags.areFlagsReady()).toBe(true);
     });
 
@@ -243,7 +247,7 @@ describe("Feature Flags - Concurrency", () => {
   });
 
   describe("Race Conditions", () => {
-    it("should handle read during concurrent loads correctly", async () => {
+    it("concurrent loadFlags() callers share a single fetch and resolve to the same value", async () => {
       let resolveCount = 0;
       let resolvers = [];
 
@@ -265,36 +269,29 @@ describe("Feature Flags - Concurrency", () => {
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await new Promise((r) => setTimeout(r, 0));
+      resolvers[0]();
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await mixpanel.flags.whenReady();
+      resolveCount = 0;
+      resolvers = [];
 
-      // Start two loads
       const load1 = mixpanel.flags.loadFlags();
       const load2 = mixpanel.flags.loadFlags();
+      expect(resolveCount).toBe(1);
 
-      // Try to read while loads are in progress
-      const variantDuringLoad = mixpanel.flags.getVariantSync("race-flag", "fallback");
-      expect(variantDuringLoad).toBe("fallback");
-
-      // Complete first load
       resolvers[0]();
-      await load1;
+      await Promise.all([load1, load2]);
 
-      // Read should now get first load's value
-      const variantAfterFirst = mixpanel.flags.getVariantSync("race-flag", "fallback");
-      expect(variantAfterFirst.value).toBe("value-0");
-
-      // Complete second load
-      resolvers[1]();
-      await load2;
-
-      // Read should now get second load's value (last one wins)
-      const variantAfterSecond = mixpanel.flags.getVariantSync("race-flag", "fallback");
-      expect(variantAfterSecond.value).toBe("value-1");
+      const variant = mixpanel.flags.getVariantSync("race-flag", "fallback");
+      expect(variant.value).toBe("value-0");
     });
 
     it("should handle interleaved async and sync reads", async () => {
       let resolveLoad;
-      global.fetch.mockImplementationOnce(() =>
+      global.fetch.mockImplementation(() =>
         new Promise(resolve => {
           resolveLoad = () => resolve({
             status: 200,
@@ -311,23 +308,21 @@ describe("Feature Flags - Concurrency", () => {
       );
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
 
-      // Start async read (will trigger load)
+      // While init's fetch is still in flight, an async read joins the same
+      // promise and a sync read sees nothing yet.
+      await new Promise((r) => setTimeout(r, 0));
       const asyncReadPromise = mixpanel.flags.getVariant("interleaved", false);
-
-      // Immediately do sync read (should return fallback)
       const syncValue = mixpanel.flags.getVariantSync("interleaved", false);
       expect(syncValue).toBe(false);
 
-      // Complete load
       resolveLoad();
 
-      // Wait for async read to complete
       const asyncValue = await asyncReadPromise;
       expect(asyncValue.value).toBe(true);
 
-      // Now sync read should also return loaded value
       const syncValueAfter = mixpanel.flags.getVariantSync("interleaved", false);
       expect(syncValueAfter.value).toBe(true);
     });
@@ -354,7 +349,15 @@ describe("Feature Flags - Concurrency", () => {
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      // Drain init's fetch first so the test's operations stand on their own.
+      await new Promise((r) => setTimeout(r, 0));
+      if (resolvers[0]) resolvers[0]();
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await mixpanel.flags.whenReady();
+      callCount = 0;
+      resolvers = [];
 
       // Start multiple concurrent operations
       operations.push(mixpanel.flags.loadFlags());

--- a/__tests__/flags-concurrency.test.js
+++ b/__tests__/flags-concurrency.test.js
@@ -106,9 +106,10 @@ describe("Feature Flags - Concurrency", () => {
       // Start loading (don't await)
       const loadPromise = mixpanel.flags.loadFlags();
 
-      // Read immediately - should return fallback since flags aren't ready
+      // Read immediately - should return wrapped fallback since flags aren't ready
       const variant = mixpanel.flags.getVariantSync("delayed", "fallback");
-      expect(variant).toBe("fallback");
+      expect(variant.value).toBe("fallback");
+      expect(variant.variant_source).toBe("fallback");
 
       // Complete load
       resolveLoad();
@@ -319,7 +320,8 @@ describe("Feature Flags - Concurrency", () => {
       await new Promise((r) => setTimeout(r, 0));
       const asyncReadPromise = mixpanel.flags.getVariant("interleaved", false);
       const syncValue = mixpanel.flags.getVariantSync("interleaved", false);
-      expect(syncValue).toBe(false);
+      expect(syncValue.value).toBe(false);
+      expect(syncValue.variant_source).toBe("fallback");
 
       resolveLoad();
 

--- a/__tests__/flags-experiment-tracking.test.js
+++ b/__tests__/flags-experiment-tracking.test.js
@@ -507,4 +507,105 @@ describe("Feature Flags - Experiment Tracking", () => {
       );
     });
   });
+
+  describe("Tracking dedup and re-tracking on refetch", () => {
+    it("fires $experiment_started only once when getVariantSync is called twice in the same tick", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: {
+              "race-flag": {
+                variant_key: "treatment",
+                variant_value: "blue",
+              },
+            },
+          }),
+      });
+
+      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
+      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      mixpanel.mixpanelImpl.track = mockTrack;
+
+      await mixpanel.flags.loadFlags();
+
+      mixpanel.flags.getVariantSync("race-flag", "fallback");
+      mixpanel.flags.getVariantSync("race-flag", "fallback");
+
+      await flushPromises();
+
+      const calls = mockTrack.mock.calls.filter(
+        ([, eventName]) => eventName === "$experiment_started"
+      );
+      expect(calls).toHaveLength(1);
+    });
+
+    it("allows a retry of $experiment_started after the first track call fails", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: {
+              "retry-flag": { variant_key: "treatment", variant_value: "v" },
+            },
+          }),
+      });
+
+      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
+      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+
+      mockTrack
+        .mockRejectedValueOnce(new Error("first track fails"))
+        .mockResolvedValue(undefined);
+      mixpanel.mixpanelImpl.track = mockTrack;
+
+      await mixpanel.flags.loadFlags();
+
+      mixpanel.flags.getVariantSync("retry-flag", "fallback");
+      await flushPromises();
+
+      mixpanel.flags.getVariantSync("retry-flag", "fallback");
+      await flushPromises();
+
+      const calls = mockTrack.mock.calls.filter(
+        ([, eventName]) => eventName === "$experiment_started"
+      );
+      expect(calls).toHaveLength(2);
+    });
+
+    it("re-tracks $experiment_started after a refetch (mirrors identify path)", async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: {
+              "refetch-flag": { variant_key: "treatment", variant_value: 1 },
+            },
+          }),
+      });
+
+      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
+      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      mixpanel.mixpanelImpl.track = mockTrack;
+
+      await mixpanel.flags.loadFlags();
+      mixpanel.flags.getVariantSync("refetch-flag", "fallback");
+      await flushPromises();
+
+      await mixpanel.flags.loadFlags();
+      mixpanel.flags.getVariantSync("refetch-flag", "fallback");
+      await flushPromises();
+
+      const calls = mockTrack.mock.calls.filter(
+        ([, eventName]) => eventName === "$experiment_started"
+      );
+      expect(calls).toHaveLength(2);
+    });
+  });
 });

--- a/__tests__/flags-js-mode.test.js
+++ b/__tests__/flags-js-mode.test.js
@@ -137,7 +137,8 @@ describe('Feature Flags - JavaScript Mode', () => {
 
       it('should return fallback from getVariant', async () => {
         const variant = await mixpanel.flags.getVariant('async-test', 'async-fallback');
-        expect(variant).toBe('async-fallback');
+        // Primitive fallbacks are wrapped to match mixpanel-js parity.
+        expect(variant).toEqual({ value: 'async-fallback', variant_source: 'fallback' });
       });
 
       it('should return fallback from getVariantValue', async () => {
@@ -152,7 +153,8 @@ describe('Feature Flags - JavaScript Mode', () => {
 
       it('should support callback pattern', (done) => {
         mixpanel.flags.getVariant('callback-test', 'callback-fallback', (variant) => {
-          expect(variant).toBe('callback-fallback');
+          // Primitive fallbacks are wrapped to match mixpanel-js parity.
+          expect(variant).toEqual({ value: 'callback-fallback', variant_source: 'fallback' });
           done();
         });
       });

--- a/__tests__/flags-js-mode.test.js
+++ b/__tests__/flags-js-mode.test.js
@@ -106,7 +106,8 @@ describe('Feature Flags - JavaScript Mode', () => {
 
       it('should return fallback from getVariantSync', () => {
         const variant = mixpanel.flags.getVariantSync('test-flag', 'fallback-value');
-        expect(variant).toBe('fallback-value');
+        expect(variant.value).toBe('fallback-value');
+        expect(variant.variant_source).toBe('fallback');
       });
 
       it('should return fallback from getVariantValueSync', () => {
@@ -208,7 +209,8 @@ describe('Feature Flags - JavaScript Mode', () => {
     it('should handle null feature names gracefully', () => {
       expect(() => mixpanel.flags.getVariantSync(null, 'fallback')).not.toThrow();
       const result = mixpanel.flags.getVariantSync(null, 'fallback');
-      expect(result).toBe('fallback');
+      expect(result.value).toBe('fallback');
+      expect(result.variant_source).toBe('fallback');
     });
 
     it('should handle undefined callbacks', async () => {

--- a/__tests__/flags-js-mode.test.js
+++ b/__tests__/flags-js-mode.test.js
@@ -138,7 +138,12 @@ describe('Feature Flags - JavaScript Mode', () => {
       it('should return fallback from getVariant', async () => {
         const variant = await mixpanel.flags.getVariant('async-test', 'async-fallback');
         // Primitive fallbacks are wrapped to match mixpanel-js parity.
-        expect(variant).toEqual({ value: 'async-fallback', variant_source: 'fallback' });
+        // Test's fetch mock returns 404 → fetch rejects, no cache → BACKEND_ERROR.
+        expect(variant).toEqual({
+          value: 'async-fallback',
+          variant_source: 'fallback',
+          fallback_reason: 'BACKEND_ERROR',
+        });
       });
 
       it('should return fallback from getVariantValue', async () => {
@@ -154,7 +159,12 @@ describe('Feature Flags - JavaScript Mode', () => {
       it('should support callback pattern', (done) => {
         mixpanel.flags.getVariant('callback-test', 'callback-fallback', (variant) => {
           // Primitive fallbacks are wrapped to match mixpanel-js parity.
-          expect(variant).toEqual({ value: 'callback-fallback', variant_source: 'fallback' });
+          // Same 404 fetch mock → BACKEND_ERROR.
+          expect(variant).toEqual({
+            value: 'callback-fallback',
+            variant_source: 'fallback',
+            fallback_reason: 'BACKEND_ERROR',
+          });
           done();
         });
       });

--- a/__tests__/flags-network.test.js
+++ b/__tests__/flags-network.test.js
@@ -59,30 +59,50 @@ describe("Feature Flags - Network Operations", () => {
         expect.stringContaining("/flags?"),
         expect.objectContaining({
           method: "GET",
-          headers: {}
+          headers: expect.objectContaining({
+            Authorization: expect.stringMatching(/^Basic /),
+          }),
         })
       );
 
       expect(mixpanel.flags.areFlagsReady()).toBe(true);
       const variant = mixpanel.flags.getVariantSync("feature-1", "fallback");
       expect(variant.value).toBe("blue");
+      expect(variant.variant_source).toBe("network");
+    });
+
+    it("should send Authorization header as HTTP Basic with token (no password)", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({ flags: {} }),
+      });
+
+      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
+      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+
+      await mixpanel.flags.loadFlags();
+
+      const fetchOptions = global.fetch.mock.calls[0][1];
+      const expected = `Basic ${Buffer.from(testToken + ":").toString("base64")}`;
+      expect(fetchOptions.headers.Authorization).toBe(expected);
     });
 
     it("should include context parameters in request", async () => {
-      global.fetch.mockResolvedValueOnce({
+      global.fetch.mockResolvedValue({
         status: 200,
         json: () => Promise.resolve({ flags: {} })
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await mixpanel.flags.whenReady();
 
-      // Update context before loading
+      global.fetch.mockClear();
       await mixpanel.flags.updateContext({ plan: "premium", feature_set: "advanced" });
-      await mixpanel.flags.loadFlags();
 
       const callUrl = global.fetch.mock.calls[0][0];
-      // Context is URL-encoded in the query string
       expect(callUrl).toContain("context=");
       expect(callUrl).toContain("premium");
       expect(callUrl).toContain("advanced");
@@ -91,93 +111,97 @@ describe("Feature Flags - Network Operations", () => {
 
   describe("Error Handling", () => {
     it("should handle 404 responses without retry for GET requests", async () => {
-      global.fetch.mockResolvedValueOnce({
+      global.fetch.mockResolvedValue({
         status: 404,
         json: () => Promise.reject(new Error("Not Found"))
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
 
-      await mixpanel.flags.loadFlags();
+      global.fetch.mockClear();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
-      // Should only call fetch once (no retries for 404)
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(mixpanel.flags.areFlagsReady()).toBe(false);
     });
 
     it("should handle malformed JSON responses", async () => {
-      global.fetch.mockResolvedValueOnce({
+      global.fetch.mockResolvedValue({
         status: 200,
         json: () => Promise.reject(new Error("Invalid JSON"))
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
 
-      await mixpanel.flags.loadFlags();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
       expect(mixpanel.flags.areFlagsReady()).toBe(false);
     });
 
     it("should handle missing flags field in response", async () => {
-      global.fetch.mockResolvedValueOnce({
+      global.fetch.mockResolvedValue({
         status: 200,
         json: () => Promise.resolve({
-          // Response without flags field
           metadata: { request_id: "123" }
         })
       });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
 
-      await mixpanel.flags.loadFlags();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
-      // Should handle gracefully and not crash
       expect(mixpanel.flags.areFlagsReady()).toBe(false);
       const variant = mixpanel.flags.getVariantSync("any-flag", "fallback");
       expect(variant).toBe("fallback");
     });
 
     it("should handle network timeout errors", async () => {
-      global.fetch.mockRejectedValueOnce(new Error("Network timeout"));
+      global.fetch.mockRejectedValue(new Error("Network timeout"));
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
 
-      await mixpanel.flags.loadFlags();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
       expect(mixpanel.flags.areFlagsReady()).toBe(false);
     });
 
     it("should not retry GET requests on client errors (4xx)", async () => {
-      // First call for initial load, then one for the actual test
-      global.fetch
-        .mockResolvedValueOnce({
-          status: 200,
-          json: () => Promise.resolve({ flags: {} })
-        })
-        .mockResolvedValueOnce({
-          status: 400,
-          json: () => Promise.reject(new Error("Bad Request"))
-        });
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({ flags: {} })
+      });
 
       mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void mixpanel.flags;
+      await mixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await mixpanel.flags.whenReady();
 
-      // Clear the mock calls from initialization
       global.fetch.mockClear();
-
-      // Now mock the failure for our actual test
       global.fetch.mockResolvedValueOnce({
         status: 400,
         json: () => Promise.reject(new Error("Bad Request"))
       });
 
-      await mixpanel.flags.loadFlags();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
-      expect(global.fetch).toHaveBeenCalledTimes(1); // No retries
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/flags-network.test.js
+++ b/__tests__/flags-network.test.js
@@ -164,7 +164,8 @@ describe("Feature Flags - Network Operations", () => {
 
       expect(mixpanel.flags.areFlagsReady()).toBe(false);
       const variant = mixpanel.flags.getVariantSync("any-flag", "fallback");
-      expect(variant).toBe("fallback");
+      expect(variant.value).toBe("fallback");
+      expect(variant.variant_source).toBe("fallback");
     });
 
     it("should handle network timeout errors", async () => {

--- a/__tests__/flags-network.test.js
+++ b/__tests__/flags-network.test.js
@@ -97,7 +97,7 @@ describe("Feature Flags - Network Operations", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await mixpanel.flags.whenReady();
+      await mixpanel.flags.loadFlags();
 
       global.fetch.mockClear();
       await mixpanel.flags.updateContext({ plan: "premium", feature_set: "advanced" });
@@ -120,7 +120,7 @@ describe("Feature Flags - Network Operations", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
       global.fetch.mockClear();
       await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
@@ -139,7 +139,7 @@ describe("Feature Flags - Network Operations", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
       await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
@@ -158,7 +158,7 @@ describe("Feature Flags - Network Operations", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
       await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
@@ -175,7 +175,7 @@ describe("Feature Flags - Network Operations", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await expect(mixpanel.flags.whenReady()).rejects.toBeDefined();
+      await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
       await expect(mixpanel.flags.loadFlags()).rejects.toBeDefined();
 
@@ -192,7 +192,7 @@ describe("Feature Flags - Network Operations", () => {
       await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void mixpanel.flags;
       await mixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await mixpanel.flags.whenReady();
+      await mixpanel.flags.loadFlags();
 
       global.fetch.mockClear();
       global.fetch.mockResolvedValueOnce({

--- a/__tests__/flags-storage.test.js
+++ b/__tests__/flags-storage.test.js
@@ -4,10 +4,11 @@ import {
   MixpanelFlagPersistence,
   VariantLookupPolicy,
 } from "../javascript/mixpanel-flag-persistence";
+import { MixpanelPersistent } from "../javascript/mixpanel-persistent";
 
 global.fetch = jest.fn();
 
-const persistedKey = (token) => `persisted_variants_for_${token}`;
+const persistedKey = (token) => `MIXPANEL_${token}_PERSISTED_FLAG_VARIANTS`;
 
 const POLICY_PERSIST_UNTIL_NET = {
   variantLookupPolicy: VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS,
@@ -23,6 +24,9 @@ describe("Feature Flags - JS-fallback Persistence (end-to-end)", () => {
     jest.clearAllMocks();
     jest.useRealTimers();
     AsyncStorage.clear();
+    // Reset the MixpanelPersistent singleton so each test's fresh mockStorage
+    // is wired through to the shared adapter that Flags now reuses.
+    MixpanelPersistent.instance = null;
     const store = {};
     mockStorage = {
       getItem: jest.fn((k) => Promise.resolve(store[k] ?? null)),

--- a/__tests__/flags-storage.test.js
+++ b/__tests__/flags-storage.test.js
@@ -39,7 +39,7 @@ describe("Feature Flags - JS-fallback Persistence (end-to-end)", () => {
         return Promise.resolve();
       }),
     };
-    global.fetch.mockClear();
+    global.fetch.mockReset();
   });
 
   afterEach(() => {

--- a/__tests__/flags-storage.test.js
+++ b/__tests__/flags-storage.test.js
@@ -156,6 +156,53 @@ describe("Feature Flags - JS-fallback Persistence (end-to-end)", () => {
     expect(keys).toContain(persistedKey(t1));
     expect(keys).toContain(persistedKey(t2));
   });
+
+  it("networkFirst falls back to the persisted variant when the network fetch fails", async () => {
+    // First session: fetch succeeds and writes a persisted blob under the runtime distinct_id.
+    global.fetch.mockResolvedValue({
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          flags: {
+            "cached-only": {
+              variant_key: "treatment",
+              variant_value: "from-persistence",
+              experiment_id: 99,
+            },
+          },
+        }),
+    });
+
+    const POLICY_NETWORK_FIRST = {
+      variantLookupPolicy: VariantLookupPolicy.NETWORK_FIRST,
+      persistenceTtlMs: 60 * 60 * 1000,
+    };
+
+    const mp = new Mixpanel(token, false, false, mockStorage);
+    await mp.init(false, {}, "https://api.mixpanel.com", false, {
+      enabled: true,
+      persistence: POLICY_NETWORK_FIRST,
+    });
+    await mp.flags.loadFlags();
+    expect(
+      mockStorage.setItem.mock.calls.some(([k]) => k === persistedKey(token))
+    ).toBe(true);
+
+    // Drive a second fetch attempt that fails; in-memory variants should survive.
+    global.fetch.mockReset();
+    global.fetch.mockRejectedValue(new Error("offline"));
+
+    await expect(mp.flags.loadFlags()).rejects.toBeDefined();
+
+    const variant = await mp.flags.getVariant("cached-only", {
+      key: "fb",
+      value: "fallback-value",
+    });
+
+    expect(variant.value).toBe("from-persistence");
+    // In-memory variant retains its origin from the original successful fetch.
+    expect(["network", "persistence"]).toContain(variant.variant_source);
+  });
 });
 
 describe("MixpanelFlagPersistence — direct unit coverage", () => {

--- a/__tests__/flags-storage.test.js
+++ b/__tests__/flags-storage.test.js
@@ -1,27 +1,44 @@
 import { Mixpanel } from "mixpanel-react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  MixpanelFlagPersistence,
+  VariantLookupPolicy,
+} from "../javascript/mixpanel-flag-persistence";
 
-// Mock fetch globally
 global.fetch = jest.fn();
 
-describe("Feature Flags - Storage", () => {
-  const testToken = "test-token-123";
+const persistedKey = (token) => `persisted_variants_for_${token}`;
+
+const POLICY_PERSIST_UNTIL_NET = {
+  variantLookupPolicy: VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS,
+  persistenceTtlMs: 60 * 60 * 1000,
+};
+
+describe("Feature Flags - JS-fallback Persistence (end-to-end)", () => {
+  const token = "test-token-123";
   let mixpanel;
-  let mockAsyncStorage;
+  let mockStorage;
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
     AsyncStorage.clear();
-
-    // Create a mock AsyncStorage for JavaScript mode
-    mockAsyncStorage = {
-      getItem: jest.fn().mockResolvedValue(null),
-      setItem: jest.fn().mockResolvedValue(undefined),
-      removeItem: jest.fn().mockResolvedValue(undefined),
-      clear: jest.fn().mockResolvedValue(undefined),
+    const store = {};
+    mockStorage = {
+      getItem: jest.fn((k) => Promise.resolve(store[k] ?? null)),
+      setItem: jest.fn((k, v) => {
+        store[k] = v;
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((k) => {
+        delete store[k];
+        return Promise.resolve();
+      }),
+      clear: jest.fn(() => {
+        for (const k of Object.keys(store)) delete store[k];
+        return Promise.resolve();
+      }),
     };
-
     global.fetch.mockClear();
   });
 
@@ -29,394 +46,223 @@ describe("Feature Flags - Storage", () => {
     jest.useRealTimers();
   });
 
-  describe("Cache Persistence", () => {
-    it("should cache flags after successful load", async () => {
-      const mockFlags = {
-        flags: {
-          "cached-feature": {
-            variant_key: "treatment",
-            variant_value: "cached-value",
-            experiment_id: 456
-          }
-        }
-      };
-
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve(mockFlags)
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      await mixpanel.flags.loadFlags();
-
-      // Check that flags were cached
-      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
-        `MIXPANEL_${testToken}_FLAGS_CACHE`,
-        expect.stringContaining("cached-feature")
-      );
-
-      // Verify the cached data format (serialized as array)
-      const cachedData = mockAsyncStorage.setItem.mock.calls[0][1];
-      const parsed = JSON.parse(cachedData);
-      expect(Array.isArray(parsed)).toBe(true);
-      expect(parsed[0][0]).toBe("cached-feature");
-      expect(parsed[0][1].value).toBe("cached-value");
-    });
-
-    // Test removed - cache loading from initialization not reliably testable in current implementation
-
-    it("should fall back to cached flags when network fails", async () => {
-      // Pre-populate cache
-      const cachedFlags = JSON.stringify([
-        ["stale-flag", {
-          key: "v1",
-          value: "stale",
-          experiment_id: 123
-        }]
-      ]);
-
-      mockAsyncStorage.getItem.mockImplementation((key) => {
-        if (key === `MIXPANEL_${testToken}_FLAGS_CACHE`) {
-          return Promise.resolve(cachedFlags);
-        }
-        return Promise.resolve(null);
-      });
-
-      // Network fails
-      global.fetch.mockRejectedValueOnce({ code: 500, message: "Server error" });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      // Wait for cache to load
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-      // Try to load fresh (will fail)
-      await mixpanel.flags.loadFlags();
-
-      // Should still have cached flags
-      expect(mixpanel.flags.areFlagsReady()).toBe(true);
-      const variant = mixpanel.flags.getVariantSync("stale-flag", "fallback");
-      expect(variant.value).toBe("stale");
-    });
-
-    it("should update cache when fresh flags are loaded", async () => {
-      // Start with cached flags
-      const oldCachedFlags = JSON.stringify([
-        ["updated-flag", {
-          key: "old",
-          value: "old-value"
-        }]
-      ]);
-
-      mockAsyncStorage.getItem.mockImplementation((key) => {
-        if (key === `MIXPANEL_${testToken}_FLAGS_CACHE`) {
-          return Promise.resolve(oldCachedFlags);
-        }
-        return Promise.resolve(null);
-      });
-
-      // Fresh flags from network
-      const freshFlags = {
-        flags: {
-          "updated-flag": {
-            variant_key: "new",
-            variant_value: "new-value"
-          },
-          "additional-flag": {
-            variant_key: "extra",
-            variant_value: true
-          }
-        }
-      };
-
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve(freshFlags)
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      // Wait for cache to load
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-      // Load fresh flags
-      await mixpanel.flags.loadFlags();
-
-      // Cache should be updated with new flags
-      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
-        `MIXPANEL_${testToken}_FLAGS_CACHE`,
-        expect.stringContaining("new-value")
-      );
-
-      // Verify updated values are accessible
-      const variant = mixpanel.flags.getVariantSync("updated-flag", "fallback");
-      expect(variant.value).toBe("new-value");
-
-      const additional = mixpanel.flags.getVariantSync("additional-flag", "fallback");
-      expect(additional.value).toBe(true);
-    });
-  });
-
-  describe("Error Handling", () => {
-    it("should handle corrupted cache data gracefully", async () => {
-      // Return corrupted data from storage
-      mockAsyncStorage.getItem.mockImplementation((key) => {
-        if (key === `MIXPANEL_${testToken}_FLAGS_CACHE`) {
-          return Promise.resolve("not-valid-json{[}");
-        }
-        return Promise.resolve(null);
-      });
-
-      // Provide valid flags from network
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve({
+  it("writes the persisted blob under the mixpanel-js key after a successful fetch", async () => {
+    global.fetch.mockResolvedValueOnce({
+      status: 200,
+      json: () =>
+        Promise.resolve({
           flags: {
-            "valid-flag": {
-              variant_key: "working",
-              variant_value: "from-network"
-            }
-          }
-        })
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      // Wait for cache attempt
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-      // Load fresh flags
-      await mixpanel.flags.loadFlags();
-
-      // Should work despite corrupted cache
-      expect(mixpanel.flags.areFlagsReady()).toBe(true);
-      const variant = mixpanel.flags.getVariantSync("valid-flag", "fallback");
-      expect(variant.value).toBe("from-network");
-    });
-
-    it("should continue working if storage read fails", async () => {
-      // Storage read fails
-      mockAsyncStorage.getItem.mockRejectedValue(new Error("Storage unavailable"));
-
-      // Network provides flags
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve({
-          flags: {
-            "no-cache-flag": {
+            "cached-feature": {
               variant_key: "treatment",
-              variant_value: "works-without-cache"
-            }
-          }
-        })
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      // Wait for failed cache attempt
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-      // Load flags from network
-      await mixpanel.flags.loadFlags();
-
-      // Should work despite storage failure
-      expect(mixpanel.flags.areFlagsReady()).toBe(true);
-      const variant = mixpanel.flags.getVariantSync("no-cache-flag", "fallback");
-      expect(variant.value).toBe("works-without-cache");
+              variant_value: "cached-value",
+              experiment_id: 456,
+            },
+          },
+        }),
     });
 
-    it("should continue working if storage write fails", async () => {
-      // Storage write fails
-      mockAsyncStorage.setItem.mockRejectedValue(new Error("Storage full"));
-
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve({
-          flags: {
-            "no-persist-flag": {
-              variant_key: "treatment",
-              variant_value: "in-memory-only"
-            }
-          }
-        })
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      await mixpanel.flags.loadFlags();
-
-      // Should work despite storage write failure
-      expect(mixpanel.flags.areFlagsReady()).toBe(true);
-      const variant = mixpanel.flags.getVariantSync("no-persist-flag", "fallback");
-      expect(variant.value).toBe("in-memory-only");
-
-      // Verify write was attempted
-      expect(mockAsyncStorage.setItem).toHaveBeenCalled();
+    mixpanel = new Mixpanel(token, false, false, mockStorage);
+    await mixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+      enabled: true,
+      persistence: POLICY_PERSIST_UNTIL_NET,
     });
+    await mixpanel.flags.loadFlags();
 
-    it("should handle invalid cache format (not an array)", async () => {
-      // Return object instead of array
-      mockAsyncStorage.getItem.mockImplementation((key) => {
-        if (key === `MIXPANEL_${testToken}_FLAGS_CACHE`) {
-          return Promise.resolve(JSON.stringify({
-            "not": "an array"
-          }));
-        }
-        return Promise.resolve(null);
-      });
-
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve({
-          flags: {
-            "recovered-flag": {
-              variant_key: "working",
-              variant_value: "recovered"
-            }
-          }
-        })
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      // Wait for cache attempt
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-      await mixpanel.flags.loadFlags();
-
-      // Should recover from invalid cache format
-      expect(mixpanel.flags.areFlagsReady()).toBe(true);
-      const variant = mixpanel.flags.getVariantSync("recovered-flag", "fallback");
-      expect(variant.value).toBe("recovered");
-    });
+    const writes = mockStorage.setItem.mock.calls.filter(
+      ([key]) => key === persistedKey(token)
+    );
+    expect(writes.length).toBeGreaterThanOrEqual(1);
+    const payload = JSON.parse(writes[writes.length - 1][1]);
+    expect(payload.flagVariants["cached-feature"].variant_key).toBe("treatment");
+    expect(payload.flagVariants["cached-feature"].variant_value).toBe("cached-value");
+    expect(payload.flagVariants["cached-feature"].experiment_id).toBe(456);
+    expect(typeof payload.persistedAt).toBe("number");
   });
 
-  describe("Cache Key Management", () => {
-    it("should use correct cache key format", async () => {
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve({
-          flags: {
-            "test": { variant_key: "a", variant_value: 1 }
-          }
-        })
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      await mixpanel.flags.loadFlags();
-
-      // Verify correct cache key format
-      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
-        `MIXPANEL_${testToken}_FLAGS_CACHE`,
-        expect.any(String)
-      );
+  it("does NOT persist when variantLookupPolicy is unset (default networkOnly)", async () => {
+    global.fetch.mockResolvedValueOnce({
+      status: 200,
+      json: () => Promise.resolve({ flags: { a: { variant_key: "k", variant_value: 1 } } }),
     });
 
-    it("should isolate cache by token", async () => {
-      const token1 = "token-1";
-      const token2 = "token-2";
+    mixpanel = new Mixpanel(token, false, false, mockStorage);
+    await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+    await mixpanel.flags.loadFlags();
 
-      // Different flags for different tokens
-      global.fetch
-        .mockResolvedValueOnce({
-          status: 200,
-          json: () => Promise.resolve({
-            flags: {
-              "flag1": { variant_key: "a", variant_value: "token1-value" }
-            }
-          })
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: () => Promise.resolve({
-            flags: {
-              "flag2": { variant_key: "b", variant_value: "token2-value" }
-            }
-          })
-        });
-
-      // Create two mixpanel instances with different tokens
-      const mixpanel1 = new Mixpanel(token1, false, false, mockAsyncStorage);
-      await mixpanel1.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-      await mixpanel1.flags.loadFlags();
-
-      const mixpanel2 = new Mixpanel(token2, false, false, mockAsyncStorage);
-      await mixpanel2.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-      await mixpanel2.flags.loadFlags();
-
-      // Verify different cache keys were used
-      const setCalls = mockAsyncStorage.setItem.mock.calls;
-      const keys = setCalls.map(call => call[0]);
-
-      expect(keys).toContain(`MIXPANEL_${token1}_FLAGS_CACHE`);
-      expect(keys).toContain(`MIXPANEL_${token2}_FLAGS_CACHE`);
-    });
+    const writesToFlagsKey = mockStorage.setItem.mock.calls.filter(
+      ([key]) => key === persistedKey(token)
+    );
+    expect(writesToFlagsKey).toHaveLength(0);
   });
 
-  describe("Cache Serialization", () => {
-    it("should correctly serialize Map to array format", async () => {
-      const complexFlags = {
-        flags: {
-          "string-flag": {
-            variant_key: "v1",
-            variant_value: "text"
-          },
-          "number-flag": {
-            variant_key: "v2",
-            variant_value: 42.5
-          },
-          "boolean-flag": {
-            variant_key: "v3",
-            variant_value: true
-          },
-          "object-flag": {
-            variant_key: "v4",
-            variant_value: { nested: "object", count: 5 }
-          },
-          "array-flag": {
-            variant_key: "v5",
-            variant_value: [1, 2, 3]
-          }
-        }
-      };
-
-      global.fetch.mockResolvedValueOnce({
-        status: 200,
-        json: () => Promise.resolve(complexFlags)
-      });
-
-      mixpanel = new Mixpanel(testToken, false, false, mockAsyncStorage);
-      await mixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-
-      await mixpanel.flags.loadFlags();
-
-      // Get cached data
-      const cachedData = mockAsyncStorage.setItem.mock.calls[0][1];
-      const parsed = JSON.parse(cachedData);
-
-      // Verify array format and data preservation
-      expect(Array.isArray(parsed)).toBe(true);
-      expect(parsed.length).toBe(5);
-
-      // Check each flag type is preserved
-      const flagsMap = new Map(parsed);
-      expect(flagsMap.get("string-flag").value).toBe("text");
-      expect(flagsMap.get("number-flag").value).toBe(42.5);
-      expect(flagsMap.get("boolean-flag").value).toBe(true);
-      expect(flagsMap.get("object-flag").value).toEqual({ nested: "object", count: 5 });
-      expect(flagsMap.get("array-flag").value).toEqual([1, 2, 3]);
+  it("stamps freshly loaded variants with variant_source='network'", async () => {
+    global.fetch.mockResolvedValueOnce({
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          flags: { "fresh-flag": { variant_key: "v1", variant_value: "new" } },
+        }),
     });
 
-    // Test removed - deserialization from cache not reliably testable without loadFlags call
+    mixpanel = new Mixpanel(token, false, false, mockStorage);
+    await mixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+      enabled: true,
+      persistence: POLICY_PERSIST_UNTIL_NET,
+    });
+    await mixpanel.flags.loadFlags();
+
+    const v = mixpanel.flags.getVariantSync("fresh-flag", { key: "k", value: null });
+    expect(v.value).toBe("new");
+    expect(v.variant_source).toBe("network");
+  });
+
+  it("isolates persisted blobs per token", async () => {
+    const t1 = "token-1";
+    const t2 = "token-2";
+
+    global.fetch
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({ flags: { a: { variant_key: "k", variant_value: "v1" } } }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({ flags: { a: { variant_key: "k", variant_value: "v1" } } }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({ flags: { b: { variant_key: "k", variant_value: "v2" } } }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({ flags: { b: { variant_key: "k", variant_value: "v2" } } }),
+      });
+
+    const mp1 = new Mixpanel(t1, false, false, mockStorage);
+    await mp1.init(false, {}, "https://api.mixpanel.com", false, {
+      enabled: true,
+      persistence: POLICY_PERSIST_UNTIL_NET,
+    });
+    await mp1.flags.loadFlags();
+
+    const mp2 = new Mixpanel(t2, false, false, mockStorage);
+    await mp2.init(false, {}, "https://api.mixpanel.com", false, {
+      enabled: true,
+      persistence: POLICY_PERSIST_UNTIL_NET,
+    });
+    await mp2.flags.loadFlags();
+
+    const keys = mockStorage.setItem.mock.calls.map(([k]) => k);
+    expect(keys).toContain(persistedKey(t1));
+    expect(keys).toContain(persistedKey(t2));
+  });
+});
+
+describe("MixpanelFlagPersistence — direct unit coverage", () => {
+  let storage;
+  const token = "unit-test-token";
+  const ttlMs = 60 * 60 * 1000;
+
+  beforeEach(() => {
+    let store = {};
+    storage = {
+      getItem: jest.fn((k) => Promise.resolve(store[k] ?? null)),
+      setItem: jest.fn((k, v) => {
+        store[k] = v;
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((k) => {
+        delete store[k];
+        return Promise.resolve();
+      }),
+    };
+  });
+
+  function makePersistence(policy = VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS, ttl = ttlMs) {
+    return new MixpanelFlagPersistence(
+      { variantLookupPolicy: policy, persistenceTtlMs: ttl },
+      token,
+      storage
+    );
+  }
+
+  it("round-trips all variant fields including variant_source and persisted_at_in_ms", async () => {
+    const p = makePersistence();
+    const context = { distinct_id: "u1" };
+    const flagsMap = new Map([
+      [
+        "flag-a",
+        {
+          key: "treatment",
+          value: { theme: "dark" },
+          experiment_id: 42,
+          is_experiment_active: true,
+          is_qa_tester: false,
+        },
+      ],
+    ]);
+
+    await p.save(context, flagsMap, {});
+    const loaded = await p.loadFlagsFromStorage(context);
+    expect(loaded).not.toBeNull();
+    const v = loaded.flags.get("flag-a");
+    expect(v.key).toBe("treatment");
+    expect(v.value).toEqual({ theme: "dark" });
+    expect(v.experiment_id).toBe(42);
+    expect(v.is_experiment_active).toBe(true);
+    expect(v.is_qa_tester).toBe(false);
+    expect(v.variant_source).toBe("persistence");
+    expect(typeof v.persisted_at_in_ms).toBe("number");
+  });
+
+  it("returns null on TTL expiry without auto-deleting the blob", async () => {
+    const p = makePersistence();
+    const context = { distinct_id: "u1" };
+    await p.save(context, new Map([["a", { key: "k", value: 1 }]]), {});
+
+    const raw = await storage.getItem(persistedKey(token));
+    const parsed = JSON.parse(raw);
+    parsed.persistedAt = Date.now() - ttlMs - 1000;
+    await storage.setItem(persistedKey(token), JSON.stringify(parsed));
+
+    const loaded = await p.loadFlagsFromStorage(context);
+    expect(loaded).toBeNull();
+
+    const stillThere = await storage.getItem(persistedKey(token));
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("clears the blob when the persisted distinct_id no longer matches", async () => {
+    const p = makePersistence();
+    await p.save({ distinct_id: "user-A" }, new Map([["a", { key: "k", value: 1 }]]), {});
+    const loaded = await p.loadFlagsFromStorage({ distinct_id: "user-B" });
+    expect(loaded).toBeNull();
+    expect(await storage.getItem(persistedKey(token))).toBeNull();
+  });
+
+  it("networkOnly policy wipes any existing blob on load", async () => {
+    const persisting = makePersistence();
+    await persisting.save({ distinct_id: "u1" }, new Map([["a", { key: "k", value: 1 }]]), {});
+    expect(await storage.getItem(persistedKey(token))).not.toBeNull();
+
+    const networkOnly = makePersistence(VariantLookupPolicy.NETWORK_ONLY);
+    const loaded = await networkOnly.loadFlagsFromStorage({ distinct_id: "u1" });
+    expect(loaded).toBeNull();
+    expect(await storage.getItem(persistedKey(token))).toBeNull();
+  });
+
+  it("save() is a no-op when policy is networkOnly", async () => {
+    const p = makePersistence(VariantLookupPolicy.NETWORK_ONLY);
+    await p.save({ distinct_id: "u1" }, new Map([["a", { key: "k", value: 1 }]]), {});
+    expect(await storage.getItem(persistedKey(token))).toBeNull();
+  });
+
+  it("rejects an invalid policy string by falling back to networkOnly", async () => {
+    const p = new MixpanelFlagPersistence(
+      { variantLookupPolicy: "totallyNotAPolicy" },
+      token,
+      storage
+    );
+    expect(p.getPolicy()).toBe(VariantLookupPolicy.NETWORK_ONLY);
   });
 });

--- a/__tests__/flags-storage.test.js
+++ b/__tests__/flags-storage.test.js
@@ -312,4 +312,29 @@ describe("MixpanelFlagPersistence — direct unit coverage", () => {
     );
     expect(p.getPolicy()).toBe(VariantLookupPolicy.NETWORK_ONLY);
   });
+
+  it("round-trips pendingFirstTimeEvents through save() and loadFlagsFromStorage()", async () => {
+    const p = makePersistence();
+    const context = { distinct_id: "u1" };
+    const flagsMap = new Map([
+      ["onboarding", { key: "control", value: false }],
+    ]);
+    const pendingFirstTimeEvents = {
+      "onboarding:abc123": {
+        flag_key: "onboarding",
+        flag_id: "flag-1",
+        project_id: 7,
+        first_time_event_hash: "abc123",
+        event_name: "Dashboard Viewed",
+        property_filters: { ">": [{ var: "x" }, 0] },
+        pending_variant: { variant_key: "treatment", variant_value: true },
+      },
+    };
+
+    await p.save(context, flagsMap, pendingFirstTimeEvents);
+    const loaded = await p.loadFlagsFromStorage(context);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded.pendingFirstTimeEvents).toEqual(pendingFirstTimeEvents);
+  });
 });

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -2,6 +2,7 @@ import { Mixpanel } from "mixpanel-react-native";
 import { NativeModules } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { MixpanelLogger } from "mixpanel-react-native/javascript/mixpanel-logger";
+import { MixpanelPersistent } from "mixpanel-react-native/javascript/mixpanel-persistent";
 
 const mockNativeModule = NativeModules.MixpanelReactNative;
 
@@ -15,6 +16,10 @@ describe("Feature Flags", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     AsyncStorage.clear();
+    // Flags now shares MixpanelPersistent's AsyncStorageAdapter, so reset the
+    // singleton between tests to prevent per-test mockStorage references from
+    // leaking into subsequent tests.
+    MixpanelPersistent.instance = null;
     if (global.fetch.mockClear) {
       global.fetch.mockClear();
     }
@@ -844,13 +849,7 @@ describe("Feature Flags", () => {
     });
   });
 
-  describe("whenReady + snake_case aliases", () => {
-    it("native mode: whenReady() resolves immediately", async () => {
-      mixpanel = new Mixpanel(testToken, false);
-      await mixpanel.init();
-      await expect(mixpanel.flags.whenReady()).resolves.toBeUndefined();
-    });
-
+  describe("load_flags snake_case alias", () => {
     it("native mode: load_flags() invokes the native bridge", async () => {
       mockNativeModule.loadFlags.mockClear();
       mockNativeModule.loadFlags.mockResolvedValueOnce(true);
@@ -860,44 +859,7 @@ describe("Feature Flags", () => {
       expect(mockNativeModule.loadFlags).toHaveBeenCalledWith(testToken);
     });
 
-    it("native mode: when_ready() resolves immediately", async () => {
-      mixpanel = new Mixpanel(testToken, false);
-      await mixpanel.init();
-      await expect(mixpanel.flags.when_ready()).resolves.toBeUndefined();
-    });
-
-    it("JS-fallback: whenReady() returns the in-flight fetchPromise during a load", async () => {
-      const mockStorage = {
-        getItem: jest.fn().mockResolvedValue(null),
-        setItem: jest.fn().mockResolvedValue(undefined),
-        removeItem: jest.fn().mockResolvedValue(undefined),
-      };
-      let resolveLoad;
-      global.fetch = jest.fn().mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            resolveLoad = () =>
-              resolve({
-                status: 200,
-                json: () => Promise.resolve({ flags: {} }),
-              });
-          })
-      );
-
-      const jsMixpanel = new Mixpanel("js-when-ready", false, false, mockStorage);
-      jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
-      void jsMixpanel.flags;
-      await new Promise((r) => setTimeout(r, 0));
-
-      const ready = jsMixpanel.flags.whenReady();
-      expect(ready).toBe(jsMixpanel.flags.jsFlags.fetchPromise);
-
-      resolveLoad();
-      await ready;
-      await expect(jsMixpanel.flags.whenReady()).resolves.toBeUndefined();
-    });
-
-    it("JS-fallback: load_flags() and when_ready() aliases work", async () => {
+    it("JS-fallback: load_flags() alias works", async () => {
       const mockStorage = {
         getItem: jest.fn().mockResolvedValue(null),
         setItem: jest.fn().mockResolvedValue(undefined),
@@ -912,7 +874,6 @@ describe("Feature Flags", () => {
       await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
 
       await expect(jsMixpanel.flags.load_flags()).resolves.toBeUndefined();
-      await expect(jsMixpanel.flags.when_ready()).resolves.toBeUndefined();
     });
   });
 
@@ -941,7 +902,7 @@ describe("Feature Flags", () => {
       await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void jsMixpanel.flags;
       await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await jsMixpanel.flags.whenReady();
+      await jsMixpanel.flags.loadFlags();
 
       jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
       jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
@@ -968,7 +929,7 @@ describe("Feature Flags", () => {
       await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void jsMixpanel.flags;
       await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await jsMixpanel.flags.whenReady();
+      await jsMixpanel.flags.loadFlags();
 
       jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
       jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
@@ -1000,7 +961,7 @@ describe("Feature Flags", () => {
       await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void jsMixpanel.flags;
       await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await jsMixpanel.flags.whenReady();
+      await jsMixpanel.flags.loadFlags();
 
       jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
       jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
@@ -1025,7 +986,7 @@ describe("Feature Flags", () => {
       await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
       void jsMixpanel.flags;
       await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await jsMixpanel.flags.whenReady();
+      await jsMixpanel.flags.loadFlags();
 
       jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
       jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
@@ -1096,12 +1057,12 @@ describe("Feature Flags", () => {
 
       jsMixpanel.reset();
       // reset() is fire-and-forget; yield so the reset chain reaches the
-      // post-reset fetch, then await it via whenReady().
+      // post-reset fetch, then await it via loadFlags().
       await new Promise((r) => setTimeout(r, 10));
-      await jsMixpanel.flags.whenReady();
+      await jsMixpanel.flags.loadFlags();
 
       expect(mockStorage.removeItem).toHaveBeenCalledWith(
-        `persisted_variants_for_${jsToken}`
+        `MIXPANEL_${jsToken}_PERSISTED_FLAG_VARIANTS`
       );
       expect(global.fetch).toHaveBeenCalled();
 
@@ -1445,7 +1406,7 @@ describe("Feature Flags", () => {
       // Touch flags to trigger lazy construction + init.
       void ftMixpanel.flags;
       await ftMixpanel.flags.jsFlags.persistenceLoadedPromise;
-      await ftMixpanel.flags.whenReady();
+      await ftMixpanel.flags.loadFlags();
     }
 
     afterEach(() => {

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -936,6 +936,8 @@ describe("Feature Flags", () => {
       expect(global.fetch).not.toHaveBeenCalled();
       expect(variant.value).toBe("fallback-value");
       expect(variant.variant_source).toBe("fallback");
+      // Persistence-stale path stamps NOT_READY (mirrors mixpanel-js).
+      expect(variant.fallback_reason).toBe("NOT_READY");
     });
 
     it("async getVariant serves the refresh after a caller invokes loadFlags()", async () => {
@@ -1016,6 +1018,8 @@ describe("Feature Flags", () => {
       const variant = jsMixpanel.flags.getVariantSync("f", { key: "x", value: "fallback" });
       expect(variant.value).toBe("fallback");
       expect(variant.variant_source).toBe("fallback");
+      // Persistence-stale path stamps NOT_READY (mirrors mixpanel-js).
+      expect(variant.fallback_reason).toBe("NOT_READY");
 
       const all = jsMixpanel.flags.getAllVariantsSync();
       expect(all).toBeInstanceOf(Map);
@@ -1198,6 +1202,74 @@ describe("Feature Flags", () => {
       await new Promise((r) => setTimeout(r, 10));
 
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fallback_reason (JS-fallback)", () => {
+    const mockStorage = () => ({
+      getItem: jest.fn().mockResolvedValue(null),
+      setItem: jest.fn().mockResolvedValue(undefined),
+      removeItem: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it("getVariantSync stamps NOT_READY before flags have loaded", () => {
+      const storage = mockStorage();
+      global.fetch = jest.fn(
+        () => new Promise(() => {})
+      );
+      const jsMixpanel = new Mixpanel("js-reason-not-ready", false, false, storage);
+      // Init started; flags not yet ready.
+      jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void jsMixpanel.flags;
+
+      const variant = jsMixpanel.flags.jsFlags.getVariantSync("anything", {
+        key: "x",
+        value: "fb",
+      });
+      expect(variant.variant_source).toBe("fallback");
+      expect(variant.fallback_reason).toBe("NOT_READY");
+    });
+
+    it("getVariantSync stamps FLAG_NOT_FOUND when key is absent from the loaded set", async () => {
+      const storage = mockStorage();
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { present: { variant_key: "k", variant_value: "v" } },
+          }),
+      });
+      const jsMixpanel = new Mixpanel("js-reason-flag-not-found", false, false, storage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      await jsMixpanel.flags.loadFlags();
+
+      const variant = jsMixpanel.flags.jsFlags.getVariantSync("absent", {
+        key: "x",
+        value: "fb",
+      });
+      expect(variant.variant_source).toBe("fallback");
+      expect(variant.fallback_reason).toBe("FLAG_NOT_FOUND");
+    });
+
+    it("getVariant (async) stamps BACKEND_ERROR when fetch fails with no cache", async () => {
+      const storage = mockStorage();
+      global.fetch = jest.fn().mockRejectedValue(new Error("offline"));
+      const jsMixpanel = new Mixpanel("js-reason-backend-error", false, false, storage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      // Force init's loadFlags to attempt and fail so this.fetchPromise
+      // exists but this.flags stays null.
+      await jsMixpanel.flags.loadFlags().catch(() => {});
+
+      const variant = await jsMixpanel.flags.jsFlags.getVariant("anything", {
+        key: "x",
+        value: "fb",
+      });
+      expect(variant.variant_source).toBe("fallback");
+      expect(variant.fallback_reason).toBe("BACKEND_ERROR");
     });
   });
 

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -117,13 +117,18 @@ describe("Feature Flags", () => {
     describe("getVariantSync", () => {
       const fallbackVariant = { key: "fallback", value: "default" };
 
-      it("should return fallback when flags not ready", () => {
+      it("delegates to native getVariantSync; native returns the fallback when not ready", () => {
         mockNativeModule.areFlagsReadySync.mockReturnValue(false);
+        mockNativeModule.getVariantSync.mockReturnValue(fallbackVariant);
 
         const variant = mixpanel.flags.getVariantSync("test-flag", fallbackVariant);
 
         expect(variant).toEqual(fallbackVariant);
-        expect(mockNativeModule.getVariantSync).not.toHaveBeenCalled();
+        expect(mockNativeModule.getVariantSync).toHaveBeenCalledWith(
+          testToken,
+          "test-flag",
+          fallbackVariant
+        );
       });
 
       it("should get variant when flags are ready", () => {
@@ -152,13 +157,18 @@ describe("Feature Flags", () => {
     });
 
     describe("getVariantValueSync", () => {
-      it("should return fallback when flags not ready", () => {
+      it("delegates to native getVariantValueSync; native returns the fallback when not ready", () => {
         mockNativeModule.areFlagsReadySync.mockReturnValue(false);
+        mockNativeModule.getVariantValueSync.mockReturnValue("default");
 
         const value = mixpanel.flags.getVariantValueSync("test-flag", "default");
 
         expect(value).toBe("default");
-        expect(mockNativeModule.getVariantValueSync).not.toHaveBeenCalled();
+        expect(mockNativeModule.getVariantValueSync).toHaveBeenCalledWith(
+          testToken,
+          "test-flag",
+          "default"
+        );
       });
 
       it("should get value when flags are ready - iOS style", () => {
@@ -225,13 +235,18 @@ describe("Feature Flags", () => {
     });
 
     describe("isEnabledSync", () => {
-      it("should return fallback when flags not ready", () => {
+      it("delegates to native isEnabledSync; native returns the fallback when not ready", () => {
         mockNativeModule.areFlagsReadySync.mockReturnValue(false);
+        mockNativeModule.isEnabledSync.mockReturnValue(false);
 
         const enabled = mixpanel.flags.isEnabledSync("test-flag", false);
 
         expect(enabled).toBe(false);
-        expect(mockNativeModule.isEnabledSync).not.toHaveBeenCalled();
+        expect(mockNativeModule.isEnabledSync).toHaveBeenCalledWith(
+          testToken,
+          "test-flag",
+          false
+        );
       });
 
       it("should check if enabled when flags are ready", () => {
@@ -1080,8 +1095,10 @@ describe("Feature Flags", () => {
       });
 
       jsMixpanel.reset();
-      await jsMixpanel.flags.jsFlags.initialLoadPromise;
+      // reset() is fire-and-forget; yield so the reset chain reaches the
+      // post-reset fetch, then await it via whenReady().
       await new Promise((r) => setTimeout(r, 10));
+      await jsMixpanel.flags.whenReady();
 
       expect(mockStorage.removeItem).toHaveBeenCalledWith(
         `persisted_variants_for_${jsToken}`

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -725,27 +725,31 @@ describe("Feature Flags", () => {
       const result = await mixpanel.flags.getAllVariants();
 
       expect(mockNativeModule.getAllVariants).toHaveBeenCalledWith(testToken);
-      expect(result).toEqual(variants);
-      expect(result["feature-1"].variant_source).toBe("network");
-      expect(result["feature-2"].persisted_at_in_ms).toBe(1717689600000);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(2);
+      expect(result.get("feature-1").variant_source).toBe("network");
+      expect(result.get("feature-2").persisted_at_in_ms).toBe(1717689600000);
     });
 
-    it("returns empty object when native returns null", async () => {
+    it("returns empty Map when native returns null", async () => {
       mockNativeModule.getAllVariants.mockResolvedValueOnce(null);
       const result = await mixpanel.flags.getAllVariants();
-      expect(result || {}).toEqual({});
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
     });
 
-    it("returns empty object when native returns an empty map", async () => {
+    it("returns empty Map when native returns an empty map", async () => {
       mockNativeModule.getAllVariants.mockResolvedValueOnce({});
       const result = await mixpanel.flags.getAllVariants();
-      expect(result).toEqual({});
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
     });
 
-    it("resolves with an empty object when the native call rejects", async () => {
+    it("resolves with an empty Map when the native call rejects", async () => {
       mockNativeModule.getAllVariants.mockRejectedValueOnce(new Error("boom"));
       const result = await mixpanel.flags.getAllVariants();
-      expect(result).toEqual({});
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
     });
 
     it("supports the callback form", async () => {
@@ -755,7 +759,8 @@ describe("Feature Flags", () => {
       const seen = await new Promise((resolve) => {
         mixpanel.flags.getAllVariants(resolve);
       });
-      expect(seen).toEqual({ a: { key: "v", value: 1 } });
+      expect(seen).toBeInstanceOf(Map);
+      expect(seen.get("a")).toEqual({ key: "v", value: 1 });
     });
 
     it("getAllVariantsSync passes through the blocking native call", () => {
@@ -764,12 +769,15 @@ describe("Feature Flags", () => {
       });
       const result = mixpanel.flags.getAllVariantsSync();
       expect(mockNativeModule.getAllVariantsSync).toHaveBeenCalledWith(testToken);
-      expect(result["feature-x"].value).toBe(1);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get("feature-x").value).toBe(1);
     });
 
-    it("getAllVariantsSync coerces a null native return to {}", () => {
+    it("getAllVariantsSync coerces a null native return to an empty Map", () => {
       mockNativeModule.getAllVariantsSync.mockReturnValueOnce(null);
-      expect(mixpanel.flags.getAllVariantsSync()).toEqual({});
+      const result = mixpanel.flags.getAllVariantsSync();
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
     });
   });
 
@@ -807,14 +815,17 @@ describe("Feature Flags", () => {
       await jsMixpanel.flags.loadFlags();
 
       const all = await jsMixpanel.flags.getAllVariants();
-      expect(Object.keys(all).sort()).toEqual(["alpha", "beta"]);
-      expect(all.alpha.value).toBe(true);
-      expect(all.alpha.variant_source).toBe("network");
+      expect(all).toBeInstanceOf(Map);
+      expect(Array.from(all.keys()).sort()).toEqual(["alpha", "beta"]);
+      expect(all.get("alpha").value).toBe(true);
+      expect(all.get("alpha").variant_source).toBe("network");
     });
 
-    it("getAllVariantsSync returns {} when no flags are loaded yet", () => {
+    it("getAllVariantsSync returns an empty Map when no flags are loaded yet", () => {
       jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
-      expect(jsMixpanel.flags.getAllVariantsSync()).toEqual({});
+      const all = jsMixpanel.flags.getAllVariantsSync();
+      expect(all).toBeInstanceOf(Map);
+      expect(all.size).toBe(0);
     });
   });
 
@@ -959,7 +970,7 @@ describe("Feature Flags", () => {
       expect(variant.value).toBe("refreshed");
     });
 
-    it("async getAllVariants returns empty object when stale and no fetch is in flight", async () => {
+    it("async getAllVariants returns empty Map when stale and no fetch is in flight", async () => {
       global.fetch.mockResolvedValueOnce({
         status: 200,
         json: () =>
@@ -980,7 +991,8 @@ describe("Feature Flags", () => {
 
       const all = await jsMixpanel.flags.getAllVariants();
       expect(global.fetch).not.toHaveBeenCalled();
-      expect(all).toEqual({});
+      expect(all).toBeInstanceOf(Map);
+      expect(all.size).toBe(0);
     });
 
     it("sync getters continue to return fallback / empty when in-memory state is stale", async () => {
@@ -1005,7 +1017,9 @@ describe("Feature Flags", () => {
       expect(variant.value).toBe("fallback");
       expect(variant.variant_source).toBe("fallback");
 
-      expect(jsMixpanel.flags.getAllVariantsSync()).toEqual({});
+      const all = jsMixpanel.flags.getAllVariantsSync();
+      expect(all).toBeInstanceOf(Map);
+      expect(all.size).toBe(0);
     });
   });
 

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -1164,4 +1164,572 @@ describe("Feature Flags", () => {
     });
   });
 
+  describe("First-Time Event Targeting", () => {
+    // Ports ~/mixpanel-js/tests/unit/flags.js:337-1070 to the RN JS-fallback
+    // path. Each test below has a 1:1 counterpart in the reference suite.
+
+    const ftToken = "ft-token";
+    const flushPromises = () => new Promise(setImmediate);
+    let mockStorage;
+    let ftMixpanel;
+
+    function defaultResponse() {
+      return {
+        flags: {
+          "onboarding-checklist": {
+            variant_key: "control",
+            variant_value: false,
+            experiment_id: null,
+            is_experiment_active: false,
+          },
+          "premium-welcome": {
+            variant_key: "control",
+            variant_value: null,
+            experiment_id: null,
+            is_experiment_active: false,
+          },
+        },
+        pending_first_time_events: [
+          {
+            flag_key: "onboarding-checklist",
+            flag_id: "flag-123",
+            project_id: 3,
+            first_time_event_hash: "abc123def456",
+            event_name: "Dashboard Viewed",
+            property_filters: {},
+            pending_variant: {
+              variant_key: "treatment",
+              variant_value: true,
+              experiment_id: 123,
+              is_experiment_active: true,
+            },
+          },
+          {
+            flag_key: "premium-welcome",
+            flag_id: "flag-456",
+            project_id: 3,
+            first_time_event_hash: "xyz789",
+            event_name: "Purchase Complete",
+            property_filters: { ">": [{ var: "amount" }, 100] },
+            pending_variant: {
+              variant_key: "premium",
+              variant_value: { discount: 20 },
+              experiment_id: 456,
+              is_experiment_active: true,
+            },
+          },
+        ],
+      };
+    }
+
+    // Build a fake fetch Response with the given JSON body.
+    function jsonResponse(body) {
+      return { status: 200, json: () => Promise.resolve(body) };
+    }
+
+    // Setup helper: stand up a fresh JS-mode Mixpanel + flags whose first
+    // fetch resolves to `body`, and wait until init's fetch settles.
+    async function setupJsMixpanel(body) {
+      global.fetch.mockReset();
+      // Default every fetch (flag fetch, recording POST) to a JSON 200.
+      // Tests can override for specific scenarios.
+      global.fetch.mockResolvedValue(jsonResponse(body));
+
+      mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+        clear: jest.fn().mockResolvedValue(undefined),
+      };
+      ftMixpanel = new Mixpanel(ftToken, false, false, mockStorage);
+      await ftMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      // Touch flags to trigger lazy construction + init.
+      void ftMixpanel.flags;
+      await ftMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await ftMixpanel.flags.whenReady();
+    }
+
+    afterEach(() => {
+      ftMixpanel = null;
+      mockStorage = null;
+    });
+
+    // ----------------------------------------------------------------------
+    // fetchFlags parsing — mixpanel-js lines 395-436
+    // ----------------------------------------------------------------------
+    describe("fetchFlags parsing", () => {
+      it("parses pending_first_time_events from response", async () => {
+        await setupJsMixpanel(defaultResponse());
+        const jsFlags = ftMixpanel.flags.jsFlags;
+        const eventKey = "onboarding-checklist:abc123def456";
+        expect(jsFlags.pendingFirstTimeEvents[eventKey]).toBeDefined();
+
+        const pending = jsFlags.pendingFirstTimeEvents[eventKey];
+        expect(pending.flag_key).toBe("onboarding-checklist");
+        expect(pending.flag_id).toBe("flag-123");
+        expect(pending.project_id).toBe(3);
+        expect(pending.first_time_event_hash).toBe("abc123def456");
+        expect(pending.event_name).toBe("Dashboard Viewed");
+        expect(pending.pending_variant.variant_key).toBe("treatment");
+      });
+
+      it("applies current variant immediately (pending variant not active yet)", async () => {
+        await setupJsMixpanel(defaultResponse());
+        const flag = ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist");
+        expect(flag.key).toBe("control");
+        expect(flag.value).toBe(false);
+      });
+
+      it("handles a response with no pending_first_time_events field", async () => {
+        await setupJsMixpanel({
+          flags: { "simple-flag": { variant_key: "enabled", variant_value: true } },
+        });
+        expect(
+          Object.keys(ftMixpanel.flags.jsFlags.pendingFirstTimeEvents)
+        ).toHaveLength(0);
+      });
+    });
+
+    // ----------------------------------------------------------------------
+    // checkFirstTimeEvents — mixpanel-js lines 438-695
+    // ----------------------------------------------------------------------
+    describe("checkFirstTimeEvents", () => {
+      beforeEach(async () => {
+        await setupJsMixpanel(defaultResponse());
+      });
+
+      it("matches event by exact name and switches variant", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+
+        const flag = ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist");
+        expect(flag.key).toBe("treatment");
+        expect(flag.value).toBe(true);
+        expect(flag.experiment_id).toBe(123);
+      });
+
+      it("does not match event with a different name", () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Other Event", {});
+        const flag = ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist");
+        expect(flag.key).toBe("control");
+        expect(flag.value).toBe(false);
+      });
+
+      it("is case-sensitive for event names", () => {
+        ftMixpanel.flags.checkFirstTimeEvents("dashboard viewed", {});
+        const flag = ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist");
+        expect(flag.key).toBe("control");
+      });
+
+      it("evaluates property filters using json-logic", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Purchase Complete", { amount: 150 });
+        await flushPromises();
+
+        const flag = ftMixpanel.flags.jsFlags.flags.get("premium-welcome");
+        expect(flag.key).toBe("premium");
+        expect(flag.value).toEqual({ discount: 20 });
+      });
+
+      it("does not match when property filters fail", () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Purchase Complete", { amount: 50 });
+        const flag = ftMixpanel.flags.jsFlags.flags.get("premium-welcome");
+        expect(flag.key).toBe("control");
+      });
+
+      it("handles undefined properties in filters", () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Purchase Complete", {});
+        const flag = ftMixpanel.flags.jsFlags.flags.get("premium-welcome");
+        expect(flag.key).toBe("control");
+      });
+
+      it("requires exact case match for property keys", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Purchase Complete", {
+          Amount: 150,
+          CATEGORY: "PREMIUM",
+        });
+        await flushPromises();
+        expect(ftMixpanel.flags.jsFlags.flags.get("premium-welcome").key).toBe(
+          "control"
+        );
+
+        ftMixpanel.flags.checkFirstTimeEvents("Purchase Complete", {
+          amount: 150,
+          category: "premium",
+        });
+        await flushPromises();
+        expect(ftMixpanel.flags.jsFlags.flags.get("premium-welcome").key).toBe(
+          "premium"
+        );
+      });
+
+      it("marks event as activated after first match", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+        const eventKey = "onboarding-checklist:abc123def456";
+        expect(
+          ftMixpanel.flags.jsFlags.activatedFirstTimeEvents[eventKey]
+        ).toBe(true);
+      });
+
+      it("does not re-trigger on subsequent matching events", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+        const eventKey = "onboarding-checklist:abc123def456";
+        expect(
+          ftMixpanel.flags.jsFlags.activatedFirstTimeEvents[eventKey]
+        ).toBe(true);
+
+        // Manually flip the variant back; a second matching call must NOT
+        // switch it (the activation is sticky for the session).
+        ftMixpanel.flags.jsFlags.flags.set("onboarding-checklist", { key: "control" });
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+        expect(ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist").key).toBe(
+          "control"
+        );
+      });
+
+      it("does not track $experiment_started (deferred to getVariant)", async () => {
+        const mockTrack = jest.fn().mockResolvedValue(undefined);
+        ftMixpanel.mixpanelImpl.track = mockTrack;
+
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+
+        const exp = mockTrack.mock.calls.filter(
+          ([, eventName]) => eventName === "$experiment_started"
+        );
+        expect(exp).toHaveLength(0);
+      });
+
+      it("calls recording endpoint with correct payload", async () => {
+        // Filter the calls to the first-time-events POST (the initial GET
+        // already used the same global.fetch mock).
+        const fetchBefore = global.fetch.mock.calls.length;
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+
+        const postCalls = global.fetch.mock.calls
+          .slice(fetchBefore)
+          .filter(([url]) => String(url).includes("first-time-events"));
+        expect(postCalls).toHaveLength(1);
+
+        const [url, options] = postCalls[0];
+        expect(url).toContain("/flags/flag-123/first-time-events");
+        expect(url).not.toContain("//flag-123");
+        expect(options.method).toBe("POST");
+        expect(options.headers["Content-Type"]).toBe("application/json");
+        expect(options.headers.Authorization).toMatch(/^Basic /);
+
+        const payload = JSON.parse(options.body);
+        expect(typeof payload.distinct_id).toBe("string");
+        expect(payload.project_id).toBe(3);
+        expect(payload.first_time_event_hash).toBe("abc123def456");
+      });
+
+      it("handles recording endpoint failures gracefully", async () => {
+        // Make subsequent fetches reject (the recording POST will be one).
+        global.fetch.mockReset();
+        global.fetch.mockRejectedValue(new Error("Network error"));
+
+        expect(() => {
+          ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        }).not.toThrow();
+        await flushPromises();
+
+        // Variant still switches; the recording failure is swallowed.
+        const flag = ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist");
+        expect(flag.key).toBe("treatment");
+      });
+
+      it("handles json-logic evaluation errors gracefully", () => {
+        const eventKey = "onboarding-checklist:abc123def456";
+        // Inject an unknown operator to force json-logic to throw.
+        ftMixpanel.flags.jsFlags.pendingFirstTimeEvents[eventKey].property_filters = {
+          totally_bogus_operator: [],
+        };
+
+        expect(() => {
+          ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        }).not.toThrow();
+
+        // Variant must NOT switch when the filter throws.
+        expect(ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist").key).toBe(
+          "control"
+        );
+      });
+
+      it("handles multiple events for the same flag independently", async () => {
+        await setupJsMixpanel({
+          flags: {
+            "multi-event-flag": { variant_key: "control", variant_value: null },
+          },
+          pending_first_time_events: [
+            {
+              flag_key: "multi-event-flag",
+              flag_id: "flag-multi",
+              project_id: 3,
+              first_time_event_hash: "cohort-A",
+              event_name: "Event A",
+              property_filters: {},
+              pending_variant: {
+                variant_key: "variant-A",
+                variant_value: "value-A",
+                experiment_id: 100,
+                is_experiment_active: true,
+              },
+            },
+            {
+              flag_key: "multi-event-flag",
+              flag_id: "flag-multi",
+              project_id: 3,
+              first_time_event_hash: "cohort-B",
+              event_name: "Event B",
+              property_filters: {},
+              pending_variant: {
+                variant_key: "variant-B",
+                variant_value: "value-B",
+                experiment_id: 200,
+                is_experiment_active: true,
+              },
+            },
+          ],
+        });
+
+        const jsFlags = ftMixpanel.flags.jsFlags;
+        const keyA = "multi-event-flag:cohort-A";
+        const keyB = "multi-event-flag:cohort-B";
+        expect(jsFlags.pendingFirstTimeEvents[keyA]).toBeDefined();
+        expect(jsFlags.pendingFirstTimeEvents[keyB]).toBeDefined();
+
+        ftMixpanel.flags.checkFirstTimeEvents("Event A", {});
+        await flushPromises();
+        expect(jsFlags.activatedFirstTimeEvents[keyA]).toBe(true);
+        expect(jsFlags.activatedFirstTimeEvents[keyB]).toBeUndefined();
+        expect(jsFlags.flags.get("multi-event-flag").key).toBe("variant-A");
+
+        ftMixpanel.flags.checkFirstTimeEvents("Event B", {});
+        await flushPromises();
+        expect(jsFlags.activatedFirstTimeEvents[keyB]).toBe(true);
+        expect(jsFlags.flags.get("multi-event-flag").key).toBe("variant-B");
+      });
+    });
+
+    // ----------------------------------------------------------------------
+    // session persistence across refetches — mixpanel-js lines 697-808
+    // ----------------------------------------------------------------------
+    describe("session persistence across refetches", () => {
+      beforeEach(async () => {
+        await setupJsMixpanel(defaultResponse());
+      });
+
+      it("preserves activated variant when flags are refetched", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+        expect(ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist").key).toBe(
+          "treatment"
+        );
+
+        // Refetch returns the same definition; the activated variant must persist.
+        await ftMixpanel.flags.loadFlags();
+        const flag = ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist");
+        expect(flag.key).toBe("treatment");
+        expect(flag.value).toBe(true);
+      });
+
+      it("does not re-add the activated flag to pendingFirstTimeEvents on refetch", async () => {
+        ftMixpanel.flags.checkFirstTimeEvents("Dashboard Viewed", {});
+        await flushPromises();
+        const eventKey = "onboarding-checklist:abc123def456";
+        expect(ftMixpanel.flags.jsFlags.activatedFirstTimeEvents[eventKey]).toBe(true);
+
+        await ftMixpanel.flags.loadFlags();
+        expect(
+          ftMixpanel.flags.jsFlags.pendingFirstTimeEvents[eventKey]
+        ).toBeUndefined();
+      });
+
+      it("allows new flags to be added on refetch", async () => {
+        // Second fetch returns a new flag + a new pending event alongside the
+        // original.
+        global.fetch.mockReset();
+        global.fetch.mockResolvedValue(
+          jsonResponse({
+            flags: {
+              "onboarding-checklist": { variant_key: "control", variant_value: false },
+              "new-flag": { variant_key: "v1", variant_value: "test" },
+            },
+            pending_first_time_events: [
+              {
+                flag_key: "onboarding-checklist",
+                flag_id: "flag-123",
+                project_id: 3,
+                first_time_event_hash: "abc123def456",
+                event_name: "Dashboard Viewed",
+                property_filters: {},
+                pending_variant: {
+                  variant_key: "treatment",
+                  variant_value: true,
+                },
+              },
+              {
+                flag_key: "new-flag",
+                flag_id: "flag-789",
+                project_id: 3,
+                first_time_event_hash: "new123",
+                event_name: "New Event",
+                property_filters: {},
+                pending_variant: {
+                  variant_key: "v2",
+                  variant_value: "test2",
+                },
+              },
+            ],
+          })
+        );
+
+        await ftMixpanel.flags.loadFlags();
+        expect(ftMixpanel.flags.jsFlags.flags.get("new-flag")).toBeDefined();
+        expect(
+          ftMixpanel.flags.jsFlags.pendingFirstTimeEvents["new-flag:new123"]
+        ).toBeDefined();
+      });
+    });
+
+    // ----------------------------------------------------------------------
+    // orphaned pending events — mixpanel-js lines 810-950
+    // ----------------------------------------------------------------------
+    describe("orphaned pending events", () => {
+      function orphanResponse() {
+        return {
+          flags: {
+            "existing-flag": { variant_key: "control", variant_value: false },
+          },
+          pending_first_time_events: [
+            {
+              flag_key: "orphaned-flag",
+              flag_id: "orphan-123",
+              project_id: 3,
+              first_time_event_hash: "orphan-hash",
+              event_name: "Orphan Event",
+              property_filters: {},
+              pending_variant: {
+                variant_key: "orphan-variant",
+                variant_value: "orphan-value",
+                experiment_id: 999,
+                is_experiment_active: true,
+              },
+            },
+          ],
+        };
+      }
+
+      it("stores pending events even if their flag is not in the flags response", async () => {
+        await setupJsMixpanel(orphanResponse());
+        const jsFlags = ftMixpanel.flags.jsFlags;
+        expect(jsFlags.pendingFirstTimeEvents["orphaned-flag:orphan-hash"]).toBeDefined();
+        expect(jsFlags.flags.has("orphaned-flag")).toBe(false);
+      });
+
+      it("creates a flag entry when an orphaned pending event activates", async () => {
+        await setupJsMixpanel(orphanResponse());
+        const jsFlags = ftMixpanel.flags.jsFlags;
+        expect(jsFlags.flags.has("orphaned-flag")).toBe(false);
+
+        const fetchBefore = global.fetch.mock.calls.length;
+        ftMixpanel.flags.checkFirstTimeEvents("Orphan Event", {});
+        await flushPromises();
+
+        expect(jsFlags.flags.has("orphaned-flag")).toBe(true);
+        const flag = jsFlags.flags.get("orphaned-flag");
+        expect(flag.key).toBe("orphan-variant");
+        expect(flag.value).toBe("orphan-value");
+        expect(flag.experiment_id).toBe(999);
+
+        // Recording POST fires exactly once.
+        const postCalls = global.fetch.mock.calls
+          .slice(fetchBefore)
+          .filter(([url]) => String(url).includes("first-time-events"));
+        expect(postCalls).toHaveLength(1);
+      });
+
+      it("preserves an activated orphan flag on refetch even if it's missing from the new response", async () => {
+        await setupJsMixpanel(orphanResponse());
+        ftMixpanel.flags.checkFirstTimeEvents("Orphan Event", {});
+        await flushPromises();
+
+        // Subsequent fetch returns a totally different set with no mention
+        // of `orphaned-flag` at all.
+        global.fetch.mockReset();
+        global.fetch.mockResolvedValue(
+          jsonResponse({
+            flags: { "some-other-flag": { variant_key: "other", variant_value: "other" } },
+            pending_first_time_events: [],
+          })
+        );
+        await ftMixpanel.flags.loadFlags();
+
+        const jsFlags = ftMixpanel.flags.jsFlags;
+        expect(jsFlags.flags.has("orphaned-flag")).toBe(true);
+        expect(jsFlags.flags.get("orphaned-flag").key).toBe("orphan-variant");
+      });
+    });
+
+    // ----------------------------------------------------------------------
+    // dynamic targeting loading — mixpanel-js lines 952-1070 (NOT PORTED).
+    // ----------------------------------------------------------------------
+    describe("dynamic targeting loading", () => {
+      // eslint-disable-next-line jest/no-disabled-tests
+      xit("N/A in RN — json-logic-js imports synchronously, no async targeting bundle", () => {
+        // The RN port replaces ~/mixpanel-js/src/targeting/loader.js
+        // (loadExtraBundle/getTargetingPromise/__mp_targeting) with a
+        // synchronous `import jsonLogic from 'json-logic-js'`. There is no
+        // script-tag injection path to test.
+      });
+    });
+
+    // ----------------------------------------------------------------------
+    // RN-specific: native-mode passthrough.
+    // ----------------------------------------------------------------------
+    describe("native-mode passthrough", () => {
+      it("checkFirstTimeEvents on the native path is a no-op", async () => {
+        const nativeMixpanel = new Mixpanel(testToken, false);
+        await nativeMixpanel.init();
+
+        // Native bridge was not given a checkFirstTimeEvents in the wrapper
+        // path; the wrapper should not invoke it on native mode. Calling
+        // must not throw.
+        expect(() => {
+          nativeMixpanel.flags.checkFirstTimeEvents("Anything", { x: 1 });
+        }).not.toThrow();
+
+        // The wrapper's native mock checkFirstTimeEvents (jest_setup) was
+        // never invoked because native is a no-op at the wrapper layer.
+        expect(mockNativeModule.checkFirstTimeEvents).not.toHaveBeenCalled();
+      });
+    });
+
+    // ----------------------------------------------------------------------
+    // RN-specific: full integration through mixpanel.track().
+    // ----------------------------------------------------------------------
+    describe("integration via mixpanel.track()", () => {
+      it("activates a pending variant when the matching event is tracked", async () => {
+        await setupJsMixpanel(defaultResponse());
+        // Pre-flight: variant is still control.
+        expect(ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist").key).toBe(
+          "control"
+        );
+
+        ftMixpanel.track("Dashboard Viewed");
+        await flushPromises();
+
+        expect(ftMixpanel.flags.jsFlags.flags.get("onboarding-checklist").key).toBe(
+          "treatment"
+        );
+      });
+    });
+  });
+
 });

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -1360,6 +1360,7 @@ describe("Feature Flags", () => {
               variant_value: true,
               experiment_id: 123,
               is_experiment_active: true,
+              is_qa_tester: true,
             },
           },
           {
@@ -1466,6 +1467,8 @@ describe("Feature Flags", () => {
         expect(flag.key).toBe("treatment");
         expect(flag.value).toBe(true);
         expect(flag.experiment_id).toBe(123);
+        expect(flag.variant_source).toBe("network");
+        expect(flag.is_qa_tester).toBe(true);
       });
 
       it("does not match event with a different name", () => {

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -1213,18 +1213,16 @@ describe("Feature Flags", () => {
       await mixpanel.flags.updateContext({ user_tier: "premium" });
       expect(mockNativeModule.updateFlagsContext).toHaveBeenCalledWith(
         testToken,
-        { user_tier: "premium" },
-        { replace: false }
+        { user_tier: "premium" }
       );
     });
 
-    it("forwards options.replace to the native bridge", async () => {
+    it("does not forward options to the native bridge (native ignores replace)", async () => {
       mockNativeModule.updateFlagsContext.mockResolvedValueOnce(undefined);
       await mixpanel.flags.updateContext({ tier: "trial" }, { replace: true });
       expect(mockNativeModule.updateFlagsContext).toHaveBeenCalledWith(
         testToken,
-        { tier: "trial" },
-        { replace: true }
+        { tier: "trial" }
       );
     });
 
@@ -1233,8 +1231,7 @@ describe("Feature Flags", () => {
       await mixpanel.flags.update_context({ user_tier: "premium" });
       expect(mockNativeModule.updateFlagsContext).toHaveBeenCalledWith(
         testToken,
-        { user_tier: "premium" },
-        { replace: false }
+        { user_tier: "premium" }
       );
     });
 

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -695,47 +695,432 @@ describe("Feature Flags", () => {
     });
   });
 
-  describe("updateContext (mixpanel-js alignment) - JavaScript mode only", () => {
+  describe("getAllVariants - native mode", () => {
     beforeEach(async () => {
       mixpanel = new Mixpanel(testToken, false);
       await mixpanel.init();
+      mockNativeModule.getAllVariants.mockReset();
+      mockNativeModule.getAllVariantsSync.mockReset();
     });
 
-    it("should throw error in native mode with descriptive message", async () => {
-      await expect(
-        mixpanel.flags.updateContext({ user_tier: "premium" })
-      ).rejects.toThrow(
-        "updateContext() is not supported in native mode"
+    it("returns the full variants map", async () => {
+      const variants = {
+        "feature-1": {
+          key: "treatment",
+          value: "blue",
+          experiment_id: 42,
+          is_experiment_active: true,
+          is_qa_tester: false,
+          variant_source: "network",
+        },
+        "feature-2": {
+          key: "control",
+          value: false,
+          variant_source: "persistence",
+          persisted_at_in_ms: 1717689600000,
+        },
+      };
+      mockNativeModule.getAllVariants.mockResolvedValueOnce(variants);
+
+      const result = await mixpanel.flags.getAllVariants();
+
+      expect(mockNativeModule.getAllVariants).toHaveBeenCalledWith(testToken);
+      expect(result).toEqual(variants);
+      expect(result["feature-1"].variant_source).toBe("network");
+      expect(result["feature-2"].persisted_at_in_ms).toBe(1717689600000);
+    });
+
+    it("returns empty object when native returns null", async () => {
+      mockNativeModule.getAllVariants.mockResolvedValueOnce(null);
+      const result = await mixpanel.flags.getAllVariants();
+      expect(result || {}).toEqual({});
+    });
+
+    it("returns empty object when native returns an empty map", async () => {
+      mockNativeModule.getAllVariants.mockResolvedValueOnce({});
+      const result = await mixpanel.flags.getAllVariants();
+      expect(result).toEqual({});
+    });
+
+    it("resolves with an empty object when the native call rejects", async () => {
+      mockNativeModule.getAllVariants.mockRejectedValueOnce(new Error("boom"));
+      const result = await mixpanel.flags.getAllVariants();
+      expect(result).toEqual({});
+    });
+
+    it("supports the callback form", async () => {
+      mockNativeModule.getAllVariants.mockResolvedValueOnce({
+        a: { key: "v", value: 1 },
+      });
+      const seen = await new Promise((resolve) => {
+        mixpanel.flags.getAllVariants(resolve);
+      });
+      expect(seen).toEqual({ a: { key: "v", value: 1 } });
+    });
+
+    it("getAllVariantsSync passes through the blocking native call", () => {
+      mockNativeModule.getAllVariantsSync.mockReturnValueOnce({
+        "feature-x": { key: "k", value: 1, variant_source: "network" },
+      });
+      const result = mixpanel.flags.getAllVariantsSync();
+      expect(mockNativeModule.getAllVariantsSync).toHaveBeenCalledWith(testToken);
+      expect(result["feature-x"].value).toBe(1);
+    });
+
+    it("getAllVariantsSync coerces a null native return to {}", () => {
+      mockNativeModule.getAllVariantsSync.mockReturnValueOnce(null);
+      expect(mixpanel.flags.getAllVariantsSync()).toEqual({});
+    });
+  });
+
+  describe("getAllVariants - JS-fallback mode", () => {
+    const jsToken = "js-mode-token";
+    let jsMixpanel;
+    let mockStorage;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn();
+    });
+
+    it("returns the full in-memory variants map after a network load", async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: {
+              alpha: { variant_key: "on", variant_value: true },
+              beta: { variant_key: "control", variant_value: "x" },
+            },
+          }),
+      });
+
+      jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      await jsMixpanel.flags.loadFlags();
+
+      const all = await jsMixpanel.flags.getAllVariants();
+      expect(Object.keys(all).sort()).toEqual(["alpha", "beta"]);
+      expect(all.alpha.value).toBe(true);
+      expect(all.alpha.variant_source).toBe("network");
+    });
+
+    it("getAllVariantsSync returns {} when no flags are loaded yet", () => {
+      jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
+      expect(jsMixpanel.flags.getAllVariantsSync()).toEqual({});
+    });
+  });
+
+  describe("whenReady + snake_case aliases", () => {
+    it("native mode: whenReady() resolves immediately", async () => {
+      mixpanel = new Mixpanel(testToken, false);
+      await mixpanel.init();
+      await expect(mixpanel.flags.whenReady()).resolves.toBeUndefined();
+    });
+
+    it("native mode: load_flags() invokes the native bridge", async () => {
+      mockNativeModule.loadFlags.mockClear();
+      mockNativeModule.loadFlags.mockResolvedValueOnce(true);
+      mixpanel = new Mixpanel(testToken, false);
+      await mixpanel.init();
+      await mixpanel.flags.load_flags();
+      expect(mockNativeModule.loadFlags).toHaveBeenCalledWith(testToken);
+    });
+
+    it("native mode: when_ready() resolves immediately", async () => {
+      mixpanel = new Mixpanel(testToken, false);
+      await mixpanel.init();
+      await expect(mixpanel.flags.when_ready()).resolves.toBeUndefined();
+    });
+
+    it("JS-fallback: whenReady() returns the in-flight fetchPromise during a load", async () => {
+      const mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      let resolveLoad;
+      global.fetch = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveLoad = () =>
+              resolve({
+                status: 200,
+                json: () => Promise.resolve({ flags: {} }),
+              });
+          })
+      );
+
+      const jsMixpanel = new Mixpanel("js-when-ready", false, false, mockStorage);
+      jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void jsMixpanel.flags;
+      await new Promise((r) => setTimeout(r, 0));
+
+      const ready = jsMixpanel.flags.whenReady();
+      expect(ready).toBe(jsMixpanel.flags.jsFlags.fetchPromise);
+
+      resolveLoad();
+      await ready;
+      await expect(jsMixpanel.flags.whenReady()).resolves.toBeUndefined();
+    });
+
+    it("JS-fallback: load_flags() and when_ready() aliases work", async () => {
+      const mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({ flags: {} }),
+      });
+
+      const jsMixpanel = new Mixpanel("js-aliases", false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+
+      await expect(jsMixpanel.flags.load_flags()).resolves.toBeUndefined();
+      await expect(jsMixpanel.flags.when_ready()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("getter ⇄ persistence consistency", () => {
+    let mockStorage;
+
+    beforeEach(() => {
+      mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn();
+    });
+
+    it("async getVariant returns fallback when in-memory state is stale and no fetch is in flight", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { f: { variant_key: "k", variant_value: "loaded" } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel("js-stale-1", false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void jsMixpanel.flags;
+      await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await jsMixpanel.flags.whenReady();
+
+      jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
+      jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
+      global.fetch.mockClear();
+
+      const variant = await jsMixpanel.flags.getVariant("f", { key: "x", value: "fallback-value" });
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(variant.value).toBe("fallback-value");
+      expect(variant.variant_source).toBe("fallback");
+    });
+
+    it("async getVariant serves the refresh after a caller invokes loadFlags()", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { f: { variant_key: "k", variant_value: "initial" } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel("js-stale-1b", false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void jsMixpanel.flags;
+      await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await jsMixpanel.flags.whenReady();
+
+      jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
+      jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
+      global.fetch.mockClear();
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { f: { variant_key: "k", variant_value: "refreshed" } },
+          }),
+      });
+
+      await jsMixpanel.flags.loadFlags();
+      const variant = await jsMixpanel.flags.getVariant("f", { key: "x", value: null });
+      expect(global.fetch).toHaveBeenCalled();
+      expect(variant.value).toBe("refreshed");
+    });
+
+    it("async getAllVariants returns empty object when stale and no fetch is in flight", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { a: { variant_key: "k", variant_value: 1 } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel("js-stale-2", false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void jsMixpanel.flags;
+      await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await jsMixpanel.flags.whenReady();
+
+      jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
+      jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
+      global.fetch.mockClear();
+
+      const all = await jsMixpanel.flags.getAllVariants();
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(all).toEqual({});
+    });
+
+    it("sync getters continue to return fallback / empty when in-memory state is stale", async () => {
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { f: { variant_key: "k", variant_value: "v" } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel("js-stale-3", false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, { enabled: true });
+      void jsMixpanel.flags;
+      await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      await jsMixpanel.flags.whenReady();
+
+      jsMixpanel.flags.jsFlags._loadedPersistedAtMs = Date.now() - 1_000_000;
+      jsMixpanel.flags.jsFlags._loadedTtlMs = 1;
+
+      const variant = jsMixpanel.flags.getVariantSync("f", { key: "x", value: "fallback" });
+      expect(variant.value).toBe("fallback");
+      expect(variant.variant_source).toBe("fallback");
+
+      expect(jsMixpanel.flags.getAllVariantsSync()).toEqual({});
+    });
+  });
+
+  describe("reset", () => {
+    it("native mode: calls native reset bridge and triggers flags.reset() no-op", async () => {
+      mixpanel = new Mixpanel(testToken, false);
+      await mixpanel.init();
+      mockNativeModule.reset.mockClear();
+      mockNativeModule.loadFlags.mockClear();
+
+      // Materialize the lazy flags property so the reset() chain reaches it.
+      void mixpanel.flags;
+      mixpanel.reset();
+
+      expect(mockNativeModule.reset).toHaveBeenCalledTimes(1);
+      expect(mockNativeModule.reset).toHaveBeenCalledWith(testToken);
+      expect(mockNativeModule.loadFlags).not.toHaveBeenCalled();
+    });
+
+    it("JS-fallback mode: clears persisted blob and triggers a fresh fetch", async () => {
+      const jsToken = "js-reset-token";
+      const mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { reset_flag: { variant_key: "v", variant_value: "after-reset" } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+        persistence: {
+          variantLookupPolicy: "persistenceUntilNetworkSuccess",
+          persistenceTtlMs: 60 * 60 * 1000,
+        },
+      });
+      await jsMixpanel.flags.loadFlags();
+
+      mockStorage.removeItem.mockClear();
+      global.fetch.mockClear();
+      global.fetch.mockResolvedValueOnce({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { reset_flag: { variant_key: "v", variant_value: "fresh" } },
+          }),
+      });
+
+      jsMixpanel.reset();
+      await jsMixpanel.flags.jsFlags.initialLoadPromise;
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockStorage.removeItem).toHaveBeenCalledWith(
+        `persisted_variants_for_${jsToken}`
+      );
+      expect(global.fetch).toHaveBeenCalled();
+      const variant = await jsMixpanel.flags.getVariant("reset_flag", {
+        key: "x",
+        value: null,
+      });
+      expect(variant.variant_source).toBe("network");
+    });
+  });
+
+  describe("updateContext", () => {
+    beforeEach(async () => {
+      mixpanel = new Mixpanel(testToken, false);
+      await mixpanel.init();
+      mockNativeModule.updateFlagsContext.mockClear();
+    });
+
+    it("forwards to the native updateFlagsContext bridge method", async () => {
+      mockNativeModule.updateFlagsContext.mockResolvedValueOnce(undefined);
+      await mixpanel.flags.updateContext({ user_tier: "premium" });
+      expect(mockNativeModule.updateFlagsContext).toHaveBeenCalledWith(
+        testToken,
+        { user_tier: "premium" },
+        { replace: false }
       );
     });
 
-    it("should throw error for update_context() snake_case alias in native mode", async () => {
-      await expect(
-        mixpanel.flags.update_context({ user_tier: "premium" })
-      ).rejects.toThrow(
-        "updateContext() is not supported in native mode"
+    it("forwards options.replace to the native bridge", async () => {
+      mockNativeModule.updateFlagsContext.mockResolvedValueOnce(undefined);
+      await mixpanel.flags.updateContext({ tier: "trial" }, { replace: true });
+      expect(mockNativeModule.updateFlagsContext).toHaveBeenCalledWith(
+        testToken,
+        { tier: "trial" },
+        { replace: true }
       );
     });
 
-    it("should provide helpful error message about initialization", async () => {
-      await expect(
-        mixpanel.flags.updateContext({ user_tier: "premium" })
-      ).rejects.toThrow(
-        "Context must be set during initialization via FeatureFlagsOptions"
+    it("works via the update_context snake_case alias", async () => {
+      mockNativeModule.updateFlagsContext.mockResolvedValueOnce(undefined);
+      await mixpanel.flags.update_context({ user_tier: "premium" });
+      expect(mockNativeModule.updateFlagsContext).toHaveBeenCalledWith(
+        testToken,
+        { user_tier: "premium" },
+        { replace: false }
       );
     });
 
-    it("should indicate feature is JavaScript mode only", async () => {
-      await expect(
-        mixpanel.flags.updateContext({ user_tier: "premium" })
-      ).rejects.toThrow(
-        "This feature is only available in JavaScript mode"
+    it("propagates native rejection to the caller", async () => {
+      mockNativeModule.updateFlagsContext.mockRejectedValueOnce(
+        new Error("native boom")
       );
+      await expect(
+        mixpanel.flags.updateContext({ x: 1 })
+      ).rejects.toThrow("native boom");
     });
-
-    // Note: Testing actual JavaScript mode behavior would require complex mocking
-    // of the mode switching logic. The JavaScript implementation is tested
-    // indirectly through integration testing with Expo/RN Web environments.
   });
 
   describe("Boolean Validation Enhancement (mixpanel-js alignment)", () => {

--- a/__tests__/flags.test.js
+++ b/__tests__/flags.test.js
@@ -1063,6 +1063,7 @@ describe("Feature Flags", () => {
         },
       });
       await jsMixpanel.flags.loadFlags();
+      const originalDistinctId = await jsMixpanel.getDistinctId();
 
       mockStorage.removeItem.mockClear();
       global.fetch.mockClear();
@@ -1082,11 +1083,121 @@ describe("Feature Flags", () => {
         `persisted_variants_for_${jsToken}`
       );
       expect(global.fetch).toHaveBeenCalled();
+
+      // The post-reset fetch must use the rotated distinct_id, not the old one.
+      const fetchURL = global.fetch.mock.calls[0][0];
+      const contextParam = new URL(fetchURL).searchParams.get("context");
+      const fetchedContext = JSON.parse(contextParam);
+      expect(fetchedContext.distinct_id).toBeTruthy();
+      expect(fetchedContext.distinct_id).not.toBe(originalDistinctId);
+
       const variant = await jsMixpanel.flags.getVariant("reset_flag", {
         key: "x",
         value: null,
       });
       expect(variant.variant_source).toBe("network");
+    });
+
+    it("JS-fallback mode: post-reset loadFlags() starts a fresh fetch, not the in-flight one", async () => {
+      const jsToken = "js-reset-inflight-token";
+      const mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn(
+        () =>
+          new Promise(() => {
+            /* never settles — keep first fetch in flight */
+          })
+      );
+
+      const jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      void jsMixpanel.flags;
+      await new Promise((r) => setTimeout(r, 0));
+      const inFlightPromise = jsMixpanel.flags.jsFlags.fetchPromise;
+      expect(inFlightPromise).not.toBeNull();
+
+      jsMixpanel.reset();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // After reset, calling loadFlags() must yield a fresh promise — not the
+      // pre-reset in-flight one (which mixpanel-js parity requires us to drop
+      // so the dedup gate doesn't keep returning it).
+      expect(jsMixpanel.flags.jsFlags.fetchPromise).not.toBe(inFlightPromise);
+    });
+  });
+
+  describe("identify (JS-fallback)", () => {
+    it("triggers a flag refetch under the new distinct_id", async () => {
+      const jsToken = "js-identify-token";
+      const mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { f: { variant_key: "v", variant_value: "x" } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      await jsMixpanel.flags.loadFlags();
+      await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      if (jsMixpanel.flags.jsFlags.fetchPromise) {
+        await jsMixpanel.flags.jsFlags.fetchPromise.catch(() => {});
+      }
+
+      global.fetch.mockClear();
+      await jsMixpanel.identify("brand-new-user");
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(global.fetch).toHaveBeenCalled();
+      const url = global.fetch.mock.calls[0][0];
+      const ctx = JSON.parse(new URL(url).searchParams.get("context"));
+      expect(ctx.distinct_id).toBe("brand-new-user");
+    });
+
+    it("does not refetch when distinct_id is unchanged", async () => {
+      const jsToken = "js-identify-noop-token";
+      const mockStorage = {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            flags: { f: { variant_key: "v", variant_value: "x" } },
+          }),
+      });
+
+      const jsMixpanel = new Mixpanel(jsToken, false, false, mockStorage);
+      await jsMixpanel.init(false, {}, "https://api.mixpanel.com", false, {
+        enabled: true,
+      });
+      await jsMixpanel.flags.loadFlags();
+      await jsMixpanel.flags.jsFlags.persistenceLoadedPromise;
+      if (jsMixpanel.flags.jsFlags.fetchPromise) {
+        await jsMixpanel.flags.jsFlags.fetchPromise.catch(() => {});
+      }
+      const sameId = await jsMixpanel.getDistinctId();
+
+      global.fetch.mockClear();
+      await jsMixpanel.identify(sameId);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -9,11 +9,23 @@ jest.mock("react-native-get-random-values", () => {
 
 jest.mock("mixpanel-react-native/javascript/mixpanel-storage", () => {
   return {
-    AsyncStorageAdapter: jest.fn().mockImplementation(() => ({
-      getItem: jest.fn().mockResolvedValue(null),
-      setItem: jest.fn().mockResolvedValue(undefined),
-      removeItem: jest.fn().mockResolvedValue(undefined),
-    })),
+    AsyncStorageAdapter: jest.fn().mockImplementation((storage) => {
+      // Delegate to the caller-supplied storage when one is provided so tests
+      // that pass a mock and then assert on its calls (e.g. flags-storage
+      // tests) see the writes.
+      if (storage) {
+        return {
+          getItem: (k) => storage.getItem(k),
+          setItem: (k, v) => storage.setItem(k, v),
+          removeItem: (k) => storage.removeItem(k),
+        };
+      }
+      return {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+      };
+    }),
   };
 });
 jest.mock("uuid", () => ({

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -75,7 +75,7 @@ jest.doMock("react-native", () => {
           clearSuperProperties: jest.fn(),
           timeEvent: jest.fn(),
           eventElapsedTime: jest.fn(),
-          reset: jest.fn(),
+          reset: jest.fn().mockResolvedValue(undefined),
           getDistinctId: jest.fn(),
           getDeviceId: jest.fn(),
           set: jest.fn(),

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -106,6 +106,7 @@ jest.doMock("react-native", () => {
           getAllVariantsSync: jest.fn().mockReturnValue({}),
           updateContext: jest.fn().mockResolvedValue(undefined),  // legacy alias, retained
           updateFlagsContext: jest.fn().mockResolvedValue(true),
+          checkFirstTimeEvents: jest.fn(),
         },
       },
     },

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -77,6 +77,7 @@ jest.doMock("react-native", () => {
           eventElapsedTime: jest.fn(),
           reset: jest.fn(),
           getDistinctId: jest.fn(),
+          getDeviceId: jest.fn(),
           set: jest.fn(),
           setOnce: jest.fn(),
           increment: jest.fn(),
@@ -101,7 +102,9 @@ jest.doMock("react-native", () => {
           getVariant: jest.fn().mockResolvedValue({ key: 'control', value: 'default' }),
           getVariantValue: jest.fn().mockResolvedValue('default'),
           isEnabled: jest.fn().mockResolvedValue(false),
-          updateContext: jest.fn().mockResolvedValue(undefined),  // Added for mixpanel-js alignment
+          getAllVariants: jest.fn().mockResolvedValue({}),
+          getAllVariantsSync: jest.fn().mockReturnValue({}),
+          updateContext: jest.fn().mockResolvedValue(undefined),  // legacy alias, retained
           updateFlagsContext: jest.fn().mockResolvedValue(true),
         },
       },

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:8.8.0'
+    implementation 'com.mixpanel.android:mixpanel-android:8.9.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.mixpanel.android:mixpanel-android:8.2.7'
+    implementation 'com.mixpanel.android:mixpanel-android:8.8.0'
 }

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -979,8 +979,21 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
                 map.putDouble("persisted_at_in_ms", (double) persistedAtMillis);
             } else if (variant.source instanceof MixpanelFlagVariant.Source.Network) {
                 map.putString("variant_source", "network");
-            } else {
+            } else if (variant.source instanceof MixpanelFlagVariant.Source.Fallback) {
                 map.putString("variant_source", "fallback");
+                MixpanelFlagVariant.Source.Fallback fallbackSource =
+                    (MixpanelFlagVariant.Source.Fallback) variant.source;
+                switch (fallbackSource.reason) {
+                    case FLAG_NOT_FOUND:
+                        map.putString("fallback_reason", "FLAG_NOT_FOUND");
+                        break;
+                    case NOT_READY:
+                        map.putString("fallback_reason", "NOT_READY");
+                        break;
+                    case BACKEND_ERROR:
+                        map.putString("fallback_reason", "BACKEND_ERROR");
+                        break;
+                }
             }
         }
 

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -1,9 +1,11 @@
 package com.mixpanel.reactnative;
 
+import com.mixpanel.android.mpmetrics.FeatureFlagOptions;
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
 import com.mixpanel.android.mpmetrics.MixpanelOptions;
 import com.mixpanel.android.mpmetrics.MixpanelFlagVariant;
 import com.mixpanel.android.mpmetrics.FlagCompletionCallback;
+import com.mixpanel.android.mpmetrics.VariantLookupPolicy;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -21,6 +23,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Arrays;
 
@@ -44,36 +47,72 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         JSONObject mixpanelProperties = ReactNativeHelper.reactToJSON(metadata);
         AutomaticProperties.setAutomaticProperties(mixpanelProperties);
 
-        // Handle feature flags options
         boolean featureFlagsEnabled = false;
         JSONObject featureFlagsContext = null;
+        VariantLookupPolicy variantLookupPolicy = null;
 
-        if (featureFlagsOptions != null && featureFlagsOptions.hasKey("enabled")) {
-            featureFlagsEnabled = featureFlagsOptions.getBoolean("enabled");
-
-            if (featureFlagsOptions.hasKey("context")) {
+        if (featureFlagsOptions != null) {
+            if (featureFlagsOptions.hasKey("enabled")) {
+                featureFlagsEnabled = featureFlagsOptions.getBoolean("enabled");
+            }
+            if (featureFlagsOptions.hasKey("context") && featureFlagsOptions.getMap("context") != null) {
                 featureFlagsContext = ReactNativeHelper.reactToJSON(featureFlagsOptions.getMap("context"));
+            }
+            if (featureFlagsOptions.hasKey("persistence")
+                    && featureFlagsOptions.getMap("persistence") != null) {
+                variantLookupPolicy = parseVariantLookupPolicy(featureFlagsOptions.getMap("persistence"));
             }
         }
 
-        // Create Mixpanel instance with feature flags configuration
         MixpanelOptions.Builder optionsBuilder = new MixpanelOptions.Builder()
             .optOutTrackingDefault(optOutTrackingDefault)
             .superProperties(mixpanelProperties)
-            .serverURL(serverURL)
-            .featureFlagsEnabled(featureFlagsEnabled);
+            .serverURL(serverURL);
 
-        if (featureFlagsContext != null) {
-            optionsBuilder.featureFlagsContext(featureFlagsContext);
+        if (featureFlagsEnabled) {
+            FeatureFlagOptions.Builder ffBuilder = new FeatureFlagOptions.Builder().enabled(true);
+            if (featureFlagsContext != null) {
+                ffBuilder.context(featureFlagsContext);
+            }
+            if (variantLookupPolicy != null) {
+                ffBuilder.variantLookupPolicy(variantLookupPolicy);
+            }
+            optionsBuilder.featureFlagOptions(ffBuilder.build());
         }
 
-        MixpanelOptions options = optionsBuilder.build();
-
-        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents, options);
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, trackAutomaticEvents, optionsBuilder.build());
         if (useGzipCompression) {
             instance.setShouldGzipRequestPayload(true);
         }
         promise.resolve(null);
+    }
+
+    private VariantLookupPolicy parseVariantLookupPolicy(ReadableMap policyMap) {
+        if (policyMap == null || !policyMap.hasKey("variantLookupPolicy")) {
+            return null;
+        }
+        String kind = policyMap.getString("variantLookupPolicy");
+        if (kind == null) {
+            return null;
+        }
+        switch (kind) {
+            case "networkOnly":
+                return VariantLookupPolicy.networkOnly();
+            case "persistenceUntilNetworkSuccess":
+                return VariantLookupPolicy.persistenceUntilNetworkSuccess(readPersistenceTtlMillis(policyMap));
+            case "networkFirst":
+                return VariantLookupPolicy.networkFirst(readPersistenceTtlMillis(policyMap));
+            default:
+                android.util.Log.w("Mixpanel", "Unknown variantLookupPolicy '" + kind + "', falling back to networkOnly");
+                return VariantLookupPolicy.networkOnly();
+        }
+    }
+
+    private long readPersistenceTtlMillis(ReadableMap policyMap) {
+        if (policyMap.hasKey("persistenceTtlMs") && !policyMap.isNull("persistenceTtlMs")) {
+            return (long) policyMap.getDouble("persistenceTtlMs");
+        }
+        return java.util.concurrent.TimeUnit.HOURS.toMillis(24);
     }
 
     @ReactMethod
@@ -808,19 +847,82 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         }
     }
 
-    // Helper methods for variant conversion
+    @ReactMethod
+    public void getAllVariants(final String token, final Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
+        if (instance == null) {
+            promise.resolve(new WritableNativeMap());
+            return;
+        }
+        synchronized (instance) {
+            instance.getFlags().getAllVariants(new FlagCompletionCallback<Map<String, MixpanelFlagVariant>>() {
+                @Override
+                public void onComplete(Map<String, MixpanelFlagVariant> variants) {
+                    WritableMap result = new WritableNativeMap();
+                    if (variants != null) {
+                        for (Map.Entry<String, MixpanelFlagVariant> entry : variants.entrySet()) {
+                            result.putMap(entry.getKey(), convertVariantToWritableMap(entry.getValue()));
+                        }
+                    }
+                    promise.resolve(result);
+                }
+            });
+        }
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap getAllVariantsSync(final String token) {
+        WritableMap result = new WritableNativeMap();
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
+        if (instance == null) {
+            return result;
+        }
+        synchronized (instance) {
+            Map<String, MixpanelFlagVariant> variants = instance.getFlags().getAllVariantsSync();
+            if (variants != null) {
+                for (Map.Entry<String, MixpanelFlagVariant> entry : variants.entrySet()) {
+                    result.putMap(entry.getKey(), convertVariantToWritableMap(entry.getValue()));
+                }
+            }
+        }
+        return result;
+    }
+
+    @ReactMethod
+    public void updateFlagsContext(final String token, ReadableMap context, ReadableMap options, final Promise promise) {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
+        if (instance == null) {
+            promise.resolve(null);
+            return;
+        }
+        final Map<String, Object> contextMap = context == null ? new HashMap<String, Object>() : ReactNativeHelper.toMap(context);
+        synchronized (instance) {
+            instance.getFlags().setContext(contextMap, new FlagCompletionCallback<Boolean>() {
+                @Override
+                public void onComplete(Boolean success) {
+                    promise.resolve(null);
+                }
+            });
+        }
+    }
+
     private MixpanelFlagVariant convertMapToVariant(ReadableMap map) {
         if (map == null) {
             return new MixpanelFlagVariant("", null);
         }
-
         String key = map.hasKey("key") ? map.getString("key") : "";
-        Object value = map.hasKey("value") ? ReactNativeHelper.dynamicToObject(map.getDynamic("value")) : null;
-        String experimentID = map.hasKey("experimentID") ? map.getString("experimentID") : null;
-        Boolean isExperimentActive = map.hasKey("isExperimentActive") ? map.getBoolean("isExperimentActive") : null;
-        Boolean isQATester = map.hasKey("isQATester") ? map.getBoolean("isQATester") : null;
-
-        // Create variant with all properties using the full constructor
+        Object value = map.hasKey("value")
+                ? ReactNativeHelper.dynamicToObject(map.getDynamic("value"))
+                : null;
+        String experimentID = map.hasKey("experiment_id") && !map.isNull("experiment_id")
+                ? map.getString("experiment_id")
+                : null;
+        Boolean isExperimentActive = map.hasKey("is_experiment_active") && !map.isNull("is_experiment_active")
+                ? map.getBoolean("is_experiment_active")
+                : null;
+        Boolean isQATester = map.hasKey("is_qa_tester") && !map.isNull("is_qa_tester")
+                ? map.getBoolean("is_qa_tester")
+                : null;
         return new MixpanelFlagVariant(key, value, experimentID, isExperimentActive, isQATester);
     }
 
@@ -834,39 +936,51 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
 
     private WritableMap convertVariantToWritableMap(MixpanelFlagVariant variant) {
         WritableMap map = new WritableNativeMap();
+        if (variant == null) {
+            return map;
+        }
 
-        if (variant != null) {
-            map.putString("key", variant.key);
+        map.putString("key", variant.key);
 
-            Object value = variant.value;
-            if (value == null) {
-                map.putNull("value");
-            } else if (value instanceof String) {
-                map.putString("value", (String) value);
-            } else if (value instanceof Boolean) {
-                map.putBoolean("value", (Boolean) value);
-            } else if (value instanceof Integer) {
-                map.putInt("value", (Integer) value);
-            } else if (value instanceof Double) {
-                map.putDouble("value", (Double) value);
-            } else if (value instanceof Float) {
-                map.putDouble("value", ((Float) value).doubleValue());
-            } else if (value instanceof Long) {
-                map.putDouble("value", ((Long) value).doubleValue());
+        Object value = variant.value;
+        if (value == null) {
+            map.putNull("value");
+        } else if (value instanceof String) {
+            map.putString("value", (String) value);
+        } else if (value instanceof Boolean) {
+            map.putBoolean("value", (Boolean) value);
+        } else if (value instanceof Integer) {
+            map.putInt("value", (Integer) value);
+        } else if (value instanceof Double) {
+            map.putDouble("value", (Double) value);
+        } else if (value instanceof Float) {
+            map.putDouble("value", ((Float) value).doubleValue());
+        } else if (value instanceof Long) {
+            map.putDouble("value", ((Long) value).doubleValue());
+        } else {
+            map.putString("value", value.toString());
+        }
+
+        if (variant.experimentID != null) {
+            map.putString("experiment_id", variant.experimentID);
+        }
+        if (variant.isExperimentActive != null) {
+            map.putBoolean("is_experiment_active", variant.isExperimentActive);
+        }
+        if (variant.isQATester != null) {
+            map.putBoolean("is_qa_tester", variant.isQATester);
+        }
+
+        if (variant.source != null) {
+            if (variant.source instanceof MixpanelFlagVariant.Source.Persistence) {
+                map.putString("variant_source", "persistence");
+                long persistedAtMillis = ((MixpanelFlagVariant.Source.Persistence) variant.source).persistedAtMillis;
+                // WritableMap has no putLong; current epoch-ms fits double precision (< 2^53).
+                map.putDouble("persisted_at_in_ms", (double) persistedAtMillis);
+            } else if (variant.source instanceof MixpanelFlagVariant.Source.Network) {
+                map.putString("variant_source", "network");
             } else {
-                // For complex objects, convert to string
-                map.putString("value", value.toString());
-            }
-
-            // Add optional fields if they exist
-            if (variant.experimentID != null) {
-                map.putString("experimentID", variant.experimentID);
-            }
-            if (variant.isExperimentActive != null) {
-                map.putBoolean("isExperimentActive", variant.isExperimentActive);
-            }
-            if (variant.isQATester != null) {
-                map.putBoolean("isQATester", variant.isQATester);
+                map.putString("variant_source", "fallback");
             }
         }
 

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -889,7 +889,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void updateFlagsContext(final String token, ReadableMap context, ReadableMap options, final Promise promise) {
+    public void updateFlagsContext(final String token, ReadableMap context, final Promise promise) {
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
         if (instance == null) {
             promise.resolve(null);

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -26,6 +26,7 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
 
@@ -112,7 +113,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         if (policyMap.hasKey("persistenceTtlMs") && !policyMap.isNull("persistenceTtlMs")) {
             return (long) policyMap.getDouble("persistenceTtlMs");
         }
-        return java.util.concurrent.TimeUnit.HOURS.toMillis(24);
+        return TimeUnit.HOURS.toMillis(24);
     }
 
     @ReactMethod
@@ -683,10 +684,8 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             promise.reject("Instance Error", "Failed to get Mixpanel instance");
             return;
         }
-        synchronized (instance) {
-            instance.getFlags().loadFlags();
-            promise.resolve(null);
-        }
+        instance.getFlags().loadFlags();
+        promise.resolve(null);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -695,9 +694,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         if (instance == null) {
             return false;
         }
-        synchronized (instance) {
-            return instance.getFlags().areFlagsReady();
-        }
+        return instance.getFlags().areFlagsReady();
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -707,11 +704,9 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return convertVariantToMap(fallback);
         }
 
-        synchronized (instance) {
-            MixpanelFlagVariant fallbackVariant = convertMapToVariant(fallback);
-            MixpanelFlagVariant variant = instance.getFlags().getVariantSync(featureName, fallbackVariant);
-            return convertVariantToWritableMap(variant);
-        }
+        MixpanelFlagVariant fallbackVariant = convertMapToVariant(fallback);
+        MixpanelFlagVariant variant = instance.getFlags().getVariantSync(featureName, fallbackVariant);
+        return convertVariantToWritableMap(variant);
     }
 
     // Note: For getVariantValueSync, we'll return the full variant and extract value in JS
@@ -727,31 +722,29 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return result;
         }
 
-        synchronized (instance) {
-            Object value = instance.getFlags().getVariantValueSync(featureName, ReactNativeHelper.dynamicToObject(fallbackValue));
-            result.putString("type", "value");
+        Object value = instance.getFlags().getVariantValueSync(featureName, ReactNativeHelper.dynamicToObject(fallbackValue));
+        result.putString("type", "value");
 
-            // Convert value to appropriate type
-            if (value == null) {
-                result.putNull("value");
-            } else if (value instanceof String) {
-                result.putString("value", (String) value);
-            } else if (value instanceof Boolean) {
-                result.putBoolean("value", (Boolean) value);
-            } else if (value instanceof Integer) {
-                result.putInt("value", (Integer) value);
-            } else if (value instanceof Double) {
-                result.putDouble("value", (Double) value);
-            } else if (value instanceof Float) {
-                result.putDouble("value", ((Float) value).doubleValue());
-            } else if (value instanceof Long) {
-                result.putDouble("value", ((Long) value).doubleValue());
-            } else {
-                result.putString("value", value.toString());
-            }
-
-            return result;
+        // Convert value to appropriate type
+        if (value == null) {
+            result.putNull("value");
+        } else if (value instanceof String) {
+            result.putString("value", (String) value);
+        } else if (value instanceof Boolean) {
+            result.putBoolean("value", (Boolean) value);
+        } else if (value instanceof Integer) {
+            result.putInt("value", (Integer) value);
+        } else if (value instanceof Double) {
+            result.putDouble("value", (Double) value);
+        } else if (value instanceof Float) {
+            result.putDouble("value", ((Float) value).doubleValue());
+        } else if (value instanceof Long) {
+            result.putDouble("value", ((Long) value).doubleValue());
+        } else {
+            result.putString("value", value.toString());
         }
+
+        return result;
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -761,9 +754,7 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return fallbackValue;
         }
 
-        synchronized (instance) {
-            return instance.getFlags().isEnabledSync(featureName, fallbackValue);
-        }
+        return instance.getFlags().isEnabledSync(featureName, fallbackValue);
     }
 
     @ReactMethod
@@ -774,15 +765,13 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        synchronized (instance) {
-            MixpanelFlagVariant fallbackVariant = convertMapToVariant(fallback);
-            instance.getFlags().getVariant(featureName, fallbackVariant, new FlagCompletionCallback<MixpanelFlagVariant>() {
-                @Override
-                public void onComplete(MixpanelFlagVariant variant) {
-                    promise.resolve(convertVariantToWritableMap(variant));
-                }
-            });
-        }
+        MixpanelFlagVariant fallbackVariant = convertMapToVariant(fallback);
+        instance.getFlags().getVariant(featureName, fallbackVariant, new FlagCompletionCallback<MixpanelFlagVariant>() {
+            @Override
+            public void onComplete(MixpanelFlagVariant variant) {
+                promise.resolve(convertVariantToWritableMap(variant));
+            }
+        });
     }
 
     @ReactMethod
@@ -793,40 +782,38 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        synchronized (instance) {
-            Object fallbackObj = ReactNativeHelper.dynamicToObject(fallbackValue);
-            instance.getFlags().getVariantValue(featureName, fallbackObj, new FlagCompletionCallback<Object>() {
-                @Override
-                public void onComplete(Object value) {
-                    // Convert the value back to a format React Native can handle
-                    if (value == null) {
-                        promise.resolve(null);
-                    } else if (value instanceof String) {
-                        promise.resolve((String) value);
-                    } else if (value instanceof Boolean) {
-                        promise.resolve((Boolean) value);
-                    } else if (value instanceof Number) {
-                        promise.resolve(((Number) value).doubleValue());
-                    } else if (value instanceof JSONObject) {
-                        try {
-                            WritableMap map = ReactNativeHelper.convertJsonToMap((JSONObject) value);
-                            promise.resolve(map);
-                        } catch (Exception e) {
-                            promise.resolve(value.toString());
-                        }
-                    } else if (value instanceof JSONArray) {
-                        try {
-                            WritableArray array = ReactNativeHelper.convertJsonToArray((JSONArray) value);
-                            promise.resolve(array);
-                        } catch (Exception e) {
-                            promise.resolve(value.toString());
-                        }
-                    } else {
+        Object fallbackObj = ReactNativeHelper.dynamicToObject(fallbackValue);
+        instance.getFlags().getVariantValue(featureName, fallbackObj, new FlagCompletionCallback<Object>() {
+            @Override
+            public void onComplete(Object value) {
+                // Convert the value back to a format React Native can handle
+                if (value == null) {
+                    promise.resolve(null);
+                } else if (value instanceof String) {
+                    promise.resolve((String) value);
+                } else if (value instanceof Boolean) {
+                    promise.resolve((Boolean) value);
+                } else if (value instanceof Number) {
+                    promise.resolve(((Number) value).doubleValue());
+                } else if (value instanceof JSONObject) {
+                    try {
+                        WritableMap map = ReactNativeHelper.convertJsonToMap((JSONObject) value);
+                        promise.resolve(map);
+                    } catch (Exception e) {
                         promise.resolve(value.toString());
                     }
+                } else if (value instanceof JSONArray) {
+                    try {
+                        WritableArray array = ReactNativeHelper.convertJsonToArray((JSONArray) value);
+                        promise.resolve(array);
+                    } catch (Exception e) {
+                        promise.resolve(value.toString());
+                    }
+                } else {
+                    promise.resolve(value.toString());
                 }
-            });
-        }
+            }
+        });
     }
 
     @ReactMethod
@@ -837,14 +824,12 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        synchronized (instance) {
-            instance.getFlags().isEnabled(featureName, fallbackValue, new FlagCompletionCallback<Boolean>() {
-                @Override
-                public void onComplete(Boolean isEnabled) {
-                    promise.resolve(isEnabled);
-                }
-            });
-        }
+        instance.getFlags().isEnabled(featureName, fallbackValue, new FlagCompletionCallback<Boolean>() {
+            @Override
+            public void onComplete(Boolean isEnabled) {
+                promise.resolve(isEnabled);
+            }
+        });
     }
 
     @ReactMethod
@@ -854,20 +839,18 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             promise.resolve(new WritableNativeMap());
             return;
         }
-        synchronized (instance) {
-            instance.getFlags().getAllVariants(new FlagCompletionCallback<Map<String, MixpanelFlagVariant>>() {
-                @Override
-                public void onComplete(Map<String, MixpanelFlagVariant> variants) {
-                    WritableMap result = new WritableNativeMap();
-                    if (variants != null) {
-                        for (Map.Entry<String, MixpanelFlagVariant> entry : variants.entrySet()) {
-                            result.putMap(entry.getKey(), convertVariantToWritableMap(entry.getValue()));
-                        }
+        instance.getFlags().getAllVariants(new FlagCompletionCallback<Map<String, MixpanelFlagVariant>>() {
+            @Override
+            public void onComplete(Map<String, MixpanelFlagVariant> variants) {
+                WritableMap result = new WritableNativeMap();
+                if (variants != null) {
+                    for (Map.Entry<String, MixpanelFlagVariant> entry : variants.entrySet()) {
+                        result.putMap(entry.getKey(), convertVariantToWritableMap(entry.getValue()));
                     }
-                    promise.resolve(result);
                 }
-            });
-        }
+                promise.resolve(result);
+            }
+        });
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -877,12 +860,10 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         if (instance == null) {
             return result;
         }
-        synchronized (instance) {
-            Map<String, MixpanelFlagVariant> variants = instance.getFlags().getAllVariantsSync();
-            if (variants != null) {
-                for (Map.Entry<String, MixpanelFlagVariant> entry : variants.entrySet()) {
-                    result.putMap(entry.getKey(), convertVariantToWritableMap(entry.getValue()));
-                }
+        Map<String, MixpanelFlagVariant> variants = instance.getFlags().getAllVariantsSync();
+        if (variants != null) {
+            for (Map.Entry<String, MixpanelFlagVariant> entry : variants.entrySet()) {
+                result.putMap(entry.getKey(), convertVariantToWritableMap(entry.getValue()));
             }
         }
         return result;
@@ -896,14 +877,12 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
             return;
         }
         final Map<String, Object> contextMap = context == null ? new HashMap<String, Object>() : ReactNativeHelper.toMap(context);
-        synchronized (instance) {
-            instance.getFlags().setContext(contextMap, new FlagCompletionCallback<Boolean>() {
-                @Override
-                public void onComplete(Boolean success) {
-                    promise.resolve(null);
-                }
-            });
-        }
+        instance.getFlags().setContext(contextMap, new FlagCompletionCallback<Boolean>() {
+            @Override
+            public void onComplete(Boolean success) {
+                promise.resolve(null);
+            }
+        });
     }
 
     private MixpanelFlagVariant convertMapToVariant(ReadableMap map) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,9 @@ export interface Flags {
   // Context management — available in both native and JavaScript modes.
   updateContext(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
 
+  // First-time event hook (JavaScript mode only; native mode is a no-op).
+  checkFirstTimeEvents(eventName: string, properties?: MixpanelProperties): void;
+
   // snake_case aliases
   are_flags_ready(): boolean;
   get_variant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
@@ -95,6 +98,7 @@ export interface Flags {
   load_flags(): Promise<void>;
   when_ready(): Promise<void>;
   update_context(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
+  check_first_time_events(eventName: string, properties?: MixpanelProperties): void;
 }
 
 export class Mixpanel {

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ export interface Flags {
   getVariantSync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
   getVariantValueSync(featureName: string, fallbackValue: any): any;
   isEnabledSync(featureName: string, fallbackValue?: boolean): boolean;
-  getAllVariantsSync(): {[featureName: string]: MixpanelFlagVariant};
+  getAllVariantsSync(): Map<string, MixpanelFlagVariant>;
 
   // Asynchronous methods with overloads for callback and Promise patterns
   getVariant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
@@ -73,8 +73,8 @@ export interface Flags {
   isEnabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
   isEnabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
 
-  getAllVariants(): Promise<{[featureName: string]: MixpanelFlagVariant}>;
-  getAllVariants(callback: (variants: {[featureName: string]: MixpanelFlagVariant}) => void): void;
+  getAllVariants(): Promise<Map<string, MixpanelFlagVariant>>;
+  getAllVariants(callback: (variants: Map<string, MixpanelFlagVariant>) => void): void;
 
   // Context management — available in both native and JavaScript modes.
   updateContext(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
@@ -90,8 +90,8 @@ export interface Flags {
   is_enabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
   is_enabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
   is_enabled_sync(featureName: string, fallbackValue?: boolean): boolean;
-  get_all_variants(): Promise<{[featureName: string]: MixpanelFlagVariant}>;
-  get_all_variants_sync(): {[featureName: string]: MixpanelFlagVariant};
+  get_all_variants(): Promise<Map<string, MixpanelFlagVariant>>;
+  get_all_variants_sync(): Map<string, MixpanelFlagVariant>;
   load_flags(): Promise<void>;
   when_ready(): Promise<void>;
   update_context(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ export type MixpanelAsyncStorage = {
 
 export type VariantSource = "network" | "persistence" | "fallback";
 
+export type FallbackReason = "FLAG_NOT_FOUND" | "NOT_READY" | "BACKEND_ERROR";
+
 export interface MixpanelFlagVariant {
   key: string;
   value: any;
@@ -16,6 +18,7 @@ export interface MixpanelFlagVariant {
   is_experiment_active?: boolean;
   is_qa_tester?: boolean;
   variant_source?: VariantSource;
+  fallback_reason?: FallbackReason;
   persisted_at_in_ms?: number;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export type FallbackReason = "FLAG_NOT_FOUND" | "NOT_READY" | "BACKEND_ERROR";
 export interface MixpanelFlagVariant {
   key: string;
   value: any;
-  experiment_id?: string | number;
+  experiment_id?: string;
   is_experiment_active?: boolean;
   is_qa_tester?: boolean;
   variant_source?: VariantSource;
@@ -60,7 +60,6 @@ export interface Flags {
   // Synchronous methods
   loadFlags(): Promise<void>;
   areFlagsReady(): boolean;
-  whenReady(): Promise<void>;
   getVariantSync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
   getVariantValueSync(featureName: string, fallbackValue: any): any;
   isEnabledSync(featureName: string, fallbackValue?: boolean): boolean;
@@ -99,7 +98,6 @@ export interface Flags {
   get_all_variants(): Promise<Map<string, MixpanelFlagVariant>>;
   get_all_variants_sync(): Map<string, MixpanelFlagVariant>;
   load_flags(): Promise<void>;
-  when_ready(): Promise<void>;
   update_context(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
   check_first_time_events(eventName: string, properties?: MixpanelProperties): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,13 +7,36 @@ export type MixpanelAsyncStorage = {
   removeItem(key: string): Promise<void>;
 };
 
+export type VariantSource = "network" | "persistence" | "fallback";
+
 export interface MixpanelFlagVariant {
   key: string;
   value: any;
-  experiment_id?: string | number;  // Updated to match mixpanel-js format
-  is_experiment_active?: boolean;    // Updated to match mixpanel-js format
-  is_qa_tester?: boolean;            // Updated to match mixpanel-js format
+  experiment_id?: string | number;
+  is_experiment_active?: boolean;
+  is_qa_tester?: boolean;
+  variant_source?: VariantSource;
+  persisted_at_in_ms?: number;
 }
+
+export interface NetworkOnlyFlagsPolicy {
+  variantLookupPolicy: "networkOnly";
+}
+
+export interface NetworkFirstFlagsPolicy {
+  variantLookupPolicy: "networkFirst";
+  persistenceTtlMs?: number;
+}
+
+export interface PersistenceUntilNetworkSuccessFlagsPolicy {
+  variantLookupPolicy: "persistenceUntilNetworkSuccess";
+  persistenceTtlMs?: number;
+}
+
+export type FlagsPersistencePolicy =
+  | NetworkOnlyFlagsPolicy
+  | NetworkFirstFlagsPolicy
+  | PersistenceUntilNetworkSuccessFlagsPolicy;
 
 export interface FeatureFlagsOptions {
   enabled?: boolean;
@@ -23,6 +46,7 @@ export interface FeatureFlagsOptions {
       [key: string]: any;
     };
   };
+  persistence?: FlagsPersistencePolicy;
 }
 
 export interface UpdateContextOptions {
@@ -33,9 +57,11 @@ export interface Flags {
   // Synchronous methods
   loadFlags(): Promise<void>;
   areFlagsReady(): boolean;
+  whenReady(): Promise<void>;
   getVariantSync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
   getVariantValueSync(featureName: string, fallbackValue: any): any;
   isEnabledSync(featureName: string, fallbackValue?: boolean): boolean;
+  getAllVariantsSync(): {[featureName: string]: MixpanelFlagVariant};
 
   // Asynchronous methods with overloads for callback and Promise patterns
   getVariant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
@@ -47,12 +73,13 @@ export interface Flags {
   isEnabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
   isEnabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
 
-  // Context management (NEW - aligned with mixpanel-js)
-  // NOTE: Only available in JavaScript mode (Expo/React Native Web)
-  // In native mode, throws an error - context must be set during initialization
+  getAllVariants(): Promise<{[featureName: string]: MixpanelFlagVariant}>;
+  getAllVariants(callback: (variants: {[featureName: string]: MixpanelFlagVariant}) => void): void;
+
+  // Context management — available in both native and JavaScript modes.
   updateContext(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
 
-  // snake_case aliases (NEW - aligned with mixpanel-js)
+  // snake_case aliases
   are_flags_ready(): boolean;
   get_variant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
   get_variant(featureName: string, fallback: MixpanelFlagVariant, callback: (result: MixpanelFlagVariant) => void): void;
@@ -63,7 +90,10 @@ export interface Flags {
   is_enabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
   is_enabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
   is_enabled_sync(featureName: string, fallbackValue?: boolean): boolean;
-  // NOTE: Only available in JavaScript mode (Expo/React Native Web)
+  get_all_variants(): Promise<{[featureName: string]: MixpanelFlagVariant}>;
+  get_all_variants_sync(): {[featureName: string]: MixpanelFlagVariant};
+  load_flags(): Promise<void>;
+  when_ready(): Promise<void>;
   update_context(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
 }
 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ export class Mixpanel {
       }
       // Lazy load the Flags instance with proper dependencies
       const Flags = require("./javascript/mixpanel-flags").Flags;
-      this._flags = new Flags(this.token, this.mixpanelImpl, this.storage);
+      this._flags = new Flags(this.token, this.mixpanelImpl);
     }
     return this._flags;
   }
@@ -637,7 +637,9 @@ export class Mixpanel {
   reset() {
     this.mixpanelImpl.reset(this.token).then(() => {
       if (this._flags) {
-        this._flags.reset();
+        this._flags.reset().catch((error) => {
+          MixpanelLogger.log(this.token, "Flags reset failed:", error);
+        });
       }
     });
   }

--- a/index.js
+++ b/index.js
@@ -635,10 +635,11 @@ export class Mixpanel {
       Useful for clearing data when a user logs out.
      */
   reset() {
-    this.mixpanelImpl.reset(this.token);
-    if (this._flags) {
-      this._flags.reset();
-    }
+    this.mixpanelImpl.reset(this.token).then(() => {
+      if (this._flags) {
+        this._flags.reset();
+      }
+    });
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -636,6 +636,9 @@ export class Mixpanel {
      */
   reset() {
     this.mixpanelImpl.reset(this.token);
+    if (this._flags) {
+      this._flags.reset();
+    }
   }
 
   /**

--- a/ios/MixpanelReactNative.m
+++ b/ios/MixpanelReactNative.m
@@ -127,6 +127,6 @@ RCT_EXTERN_METHOD(getAllVariants:(NSString *)token resolver:(RCTPromiseResolveBl
 
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(getAllVariantsSync:(NSString *)token)
 
-RCT_EXTERN_METHOD(updateFlagsContext:(NSString *)token context:(NSDictionary *)context options:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(updateFlagsContext:(NSString *)token context:(NSDictionary *)context resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/MixpanelReactNative.m
+++ b/ios/MixpanelReactNative.m
@@ -123,4 +123,10 @@ RCT_EXTERN_METHOD(getVariantValue:(NSString *)token featureName:(NSString *)feat
 
 RCT_EXTERN_METHOD(isEnabled:(NSString *)token featureName:(NSString *)featureName fallbackValue:(BOOL)fallbackValue resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getAllVariants:(NSString *)token resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(getAllVariantsSync:(NSString *)token)
+
+RCT_EXTERN_METHOD(updateFlagsContext:(NSString *)token context:(NSDictionary *)context options:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -719,17 +719,8 @@ open class MixpanelReactNative: NSObject {
         case .persistence(let persistedAt):
             dict["variant_source"] = "persistence"
             dict["persisted_at_in_ms"] = Int64(persistedAt.timeIntervalSince1970 * 1000)
-        case .fallback(let reason):
+        case .fallback:
             dict["variant_source"] = "fallback"
-            // The SDK's `.fallback` associated value is optional
-            // (`FallbackReason?`); nil when the SDK didn't populate a reason.
-            if let reason = reason {
-                switch reason {
-                case .flagNotFound: dict["fallback_reason"] = "FLAG_NOT_FOUND"
-                case .notReady:     dict["fallback_reason"] = "NOT_READY"
-                case .backendError: dict["fallback_reason"] = "BACKEND_ERROR"
-                }
-            }
         }
 
         return dict

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -668,7 +668,6 @@ open class MixpanelReactNative: NSObject {
     @objc
     func updateFlagsContext(_ token: String,
                             context: [String: Any],
-                            options: [String: Any]?,
                             resolver resolve: @escaping RCTPromiseResolveBlock,
                             rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let instance = MixpanelReactNative.getMixpanelInstance(token),

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -721,10 +721,13 @@ open class MixpanelReactNative: NSObject {
             dict["persisted_at_in_ms"] = Int64(persistedAt.timeIntervalSince1970 * 1000)
         case .fallback(let reason):
             dict["variant_source"] = "fallback"
+            // reason is FallbackReason? — older Mixpanel-swift builds may not
+            // populate it, so handle .none by omitting fallback_reason.
             switch reason {
             case .flagNotFound: dict["fallback_reason"] = "FLAG_NOT_FOUND"
             case .notReady:     dict["fallback_reason"] = "NOT_READY"
             case .backendError: dict["fallback_reason"] = "BACKEND_ERROR"
+            case .none:         break
             }
         }
 

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -719,8 +719,13 @@ open class MixpanelReactNative: NSObject {
         case .persistence(let persistedAt):
             dict["variant_source"] = "persistence"
             dict["persisted_at_in_ms"] = Int64(persistedAt.timeIntervalSince1970 * 1000)
-        case .fallback:
+        case .fallback(let reason):
             dict["variant_source"] = "fallback"
+            switch reason {
+            case .flagNotFound: dict["fallback_reason"] = "FLAG_NOT_FOUND"
+            case .notReady:     dict["fallback_reason"] = "NOT_READY"
+            case .backendError: dict["fallback_reason"] = "BACKEND_ERROR"
+            }
         }
 
         return dict

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -25,16 +25,18 @@ open class MixpanelReactNative: NSObject {
         AutomaticProperties.setAutomaticProperties(autoProps)
         let propsProcessed = MixpanelTypeHandler.processProperties(properties: autoProps)
 
-        // Handle feature flags options
-        var featureFlagsEnabled = false
-        var featureFlagsContext: [String: Any]? = nil
-
-        if let flagsOptions = featureFlagsOptions {
-            featureFlagsEnabled = flagsOptions["enabled"] as? Bool ?? false
-            featureFlagsContext = flagsOptions["context"] as? [String: Any]
+        var resolvedFeatureFlagOptions: FeatureFlagOptions? = nil
+        if let flagsOptions = featureFlagsOptions,
+           let enabled = flagsOptions["enabled"] as? Bool, enabled {
+            let context = flagsOptions["context"] as? [String: Any] ?? [:]
+            let policy = parseVariantLookupPolicy(flagsOptions["persistence"] as? [String: Any])
+            resolvedFeatureFlagOptions = FeatureFlagOptions(
+                enabled: true,
+                context: context,
+                variantLookupPolicy: policy
+            )
         }
 
-        // Create MixpanelOptions with all configuration including feature flags
         let options = MixpanelOptions(
             token: token,
             flushInterval: Constants.DEFAULT_FLUSH_INTERVAL,
@@ -46,12 +48,35 @@ open class MixpanelReactNative: NSObject {
             serverURL: serverURL,
             proxyServerConfig: nil,
             useGzipCompression: useGzipCompression,
-            featureFlagsEnabled: featureFlagsEnabled,
-            featureFlagsContext: featureFlagsContext ?? [:]
+            featureFlagOptions: resolvedFeatureFlagOptions
         )
 
         Mixpanel.initialize(options: options)
         resolve(true)
+    }
+
+    private func parseVariantLookupPolicy(_ policyMap: [String: Any]?) -> VariantLookupPolicy {
+        guard let policyMap = policyMap, let kind = policyMap["variantLookupPolicy"] as? String else {
+            return .networkOnly
+        }
+        switch kind {
+        case "networkOnly":
+            return .networkOnly
+        case "persistenceUntilNetworkSuccess":
+            return .persistenceUntilNetworkSuccess(persistenceTtl: readPersistenceTtlSeconds(policyMap))
+        case "networkFirst":
+            return .networkFirst(persistenceTtl: readPersistenceTtlSeconds(policyMap))
+        default:
+            NSLog("[Mixpanel] Unknown variantLookupPolicy '\(kind)', falling back to networkOnly")
+            return .networkOnly
+        }
+    }
+
+    private func readPersistenceTtlSeconds(_ policyMap: [String: Any]) -> TimeInterval {
+        if let millis = policyMap["persistenceTtlMs"] as? NSNumber {
+            return TimeInterval(truncating: millis) / 1000.0
+        }
+        return 24 * 60 * 60
     }
 
     @objc
@@ -606,14 +631,64 @@ open class MixpanelReactNative: NSObject {
         }
     }
 
-    // Helper methods for variant conversion
+    // MARK: - Feature Flags (getAllVariants / updateFlagsContext)
+
+    @objc
+    func getAllVariants(_ token: String,
+                        resolver resolve: @escaping RCTPromiseResolveBlock,
+                        rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        guard let instance = MixpanelReactNative.getMixpanelInstance(token),
+              let flags = instance.flags else {
+            resolve([String: Any]())
+            return
+        }
+        flags.getAllVariants { variants in
+            var out = [String: [String: Any]]()
+            for (key, variant) in variants {
+                out[key] = self.convertVariantToDict(variant)
+            }
+            resolve(out)
+        }
+    }
+
+    @objc
+    func getAllVariantsSync(_ token: String) -> [String: [String: Any]] {
+        guard let instance = MixpanelReactNative.getMixpanelInstance(token),
+              let flags = instance.flags else {
+            return [:]
+        }
+        let variants = flags.getAllVariantsSync()
+        var out = [String: [String: Any]]()
+        for (key, variant) in variants {
+            out[key] = self.convertVariantToDict(variant)
+        }
+        return out
+    }
+
+    @objc
+    func updateFlagsContext(_ token: String,
+                            context: [String: Any],
+                            options: [String: Any]?,
+                            resolver resolve: @escaping RCTPromiseResolveBlock,
+                            rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        guard let instance = MixpanelReactNative.getMixpanelInstance(token),
+              let flags = instance.flags else {
+            resolve(nil)
+            return
+        }
+        flags.setContext(context) {
+            resolve(nil)
+        }
+    }
+
+    // MARK: - Variant conversion
+
     private func convertDictToVariant(_ dict: [String: Any]) -> MixpanelFlagVariant {
         let key = dict["key"] as? String ?? ""
         let value = dict["value"] ?? NSNull()
-        let experimentID = dict["experimentID"] as? String
-        let isExperimentActive = dict["isExperimentActive"] as? Bool
-        let isQATester = dict["isQATester"] as? Bool
-
+        let experimentID = dict["experiment_id"] as? String
+        let isExperimentActive = dict["is_experiment_active"] as? Bool
+        let isQATester = dict["is_qa_tester"] as? Bool
         return MixpanelFlagVariant(
             key: key,
             value: value,
@@ -630,10 +705,24 @@ open class MixpanelReactNative: NSObject {
         ]
 
         if let experimentID = variant.experimentID {
-            dict["experimentID"] = experimentID
+            dict["experiment_id"] = experimentID
         }
-        dict["isExperimentActive"] = variant.isExperimentActive
-        dict["isQATester"] = variant.isQATester
+        if let isExperimentActive = variant.isExperimentActive {
+            dict["is_experiment_active"] = isExperimentActive
+        }
+        if let isQATester = variant.isQATester {
+            dict["is_qa_tester"] = isQATester
+        }
+
+        switch variant.source {
+        case .network:
+            dict["variant_source"] = "network"
+        case .persistence(let persistedAt):
+            dict["variant_source"] = "persistence"
+            dict["persisted_at_in_ms"] = Int64(persistedAt.timeIntervalSince1970 * 1000)
+        case .fallback:
+            dict["variant_source"] = "fallback"
+        }
 
         return dict
     }

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -721,13 +721,14 @@ open class MixpanelReactNative: NSObject {
             dict["persisted_at_in_ms"] = Int64(persistedAt.timeIntervalSince1970 * 1000)
         case .fallback(let reason):
             dict["variant_source"] = "fallback"
-            // reason is FallbackReason? — older Mixpanel-swift builds may not
-            // populate it, so handle .none by omitting fallback_reason.
-            switch reason {
-            case .flagNotFound: dict["fallback_reason"] = "FLAG_NOT_FOUND"
-            case .notReady:     dict["fallback_reason"] = "NOT_READY"
-            case .backendError: dict["fallback_reason"] = "BACKEND_ERROR"
-            case .none:         break
+            // The SDK's `.fallback` associated value is optional
+            // (`FallbackReason?`); nil when the SDK didn't populate a reason.
+            if let reason = reason {
+                switch reason {
+                case .flagNotFound: dict["fallback_reason"] = "FLAG_NOT_FOUND"
+                case .notReady:     dict["fallback_reason"] = "NOT_READY"
+                case .backendError: dict["fallback_reason"] = "BACKEND_ERROR"
+                }
             }
         }
 

--- a/javascript/mixpanel-constants.js
+++ b/javascript/mixpanel-constants.js
@@ -16,6 +16,8 @@ export const getSuperPropertiesKey = (token) =>
 export const getTimeEventsKey = (token) => `MIXPANEL_${token}_TIME_EVENTS`;
 export const getAppHasOpenedBeforeKey = (token) =>
   `MIXPANEL_${token}_APP_HAS_OPENED_BEFORE`;
+export const getPersistedVariantsKey = (token) =>
+  `MIXPANEL_${token}_PERSISTED_FLAG_VARIANTS`;
 
 export const defaultServerURL = `https://api.mixpanel.com`;
 export const defaultBatchSize = 50;

--- a/javascript/mixpanel-flag-persistence.js
+++ b/javascript/mixpanel-flag-persistence.js
@@ -133,12 +133,13 @@ export class MixpanelFlagPersistence {
 
     return {
       flags: persistedFlags,
+      pendingFirstTimeEvents: data.pendingFirstTimeEvents || {},
       persistedAtMs: data.persistedAt,
       ttlMs: ttlMs,
     };
   }
 
-  async save(context, flagsMap) {
+  async save(context, flagsMap, pendingFirstTimeEvents) {
     if (this.getPolicy() === VariantLookupPolicy.NETWORK_ONLY) {
       return;
     }
@@ -159,6 +160,7 @@ export class MixpanelFlagPersistence {
       distinctId: context && context.distinct_id,
       context: context,
       flagVariants: flagVariants,
+      pendingFirstTimeEvents: pendingFirstTimeEvents || {},
     };
 
     try {

--- a/javascript/mixpanel-flag-persistence.js
+++ b/javascript/mixpanel-flag-persistence.js
@@ -1,6 +1,6 @@
 import { MixpanelLogger } from './mixpanel-logger';
+import { getPersistedVariantsKey } from './mixpanel-constants';
 
-const PERSISTED_VARIANTS_KEY_PREFIX = 'persisted_variants_for_';
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 const VariantLookupPolicy = Object.freeze({
@@ -23,7 +23,7 @@ const VALID_POLICIES = [
 export class MixpanelFlagPersistence {
   constructor(persistence, token, storage) {
     this.persistence = persistence;
-    this.persistedVariantsKey = PERSISTED_VARIANTS_KEY_PREFIX + token;
+    this.persistedVariantsKey = getPersistedVariantsKey(token);
     this.storage = storage;
     this.token = token;
   }
@@ -187,4 +187,4 @@ export class MixpanelFlagPersistence {
   }
 }
 
-export { VariantLookupPolicy, PERSISTED_VARIANTS_KEY_PREFIX, DEFAULT_TTL_MS };
+export { VariantLookupPolicy, DEFAULT_TTL_MS };

--- a/javascript/mixpanel-flag-persistence.js
+++ b/javascript/mixpanel-flag-persistence.js
@@ -1,0 +1,188 @@
+import { MixpanelLogger } from './mixpanel-logger';
+
+const PERSISTED_VARIANTS_KEY_PREFIX = 'persisted_variants_for_';
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const VariantLookupPolicy = Object.freeze({
+  NETWORK_ONLY: 'networkOnly',
+  NETWORK_FIRST: 'networkFirst',
+  PERSISTENCE_UNTIL_NETWORK_SUCCESS: 'persistenceUntilNetworkSuccess',
+});
+
+const VALID_POLICIES = [
+  VariantLookupPolicy.NETWORK_ONLY,
+  VariantLookupPolicy.NETWORK_FIRST,
+  VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS,
+];
+
+/**
+ * Storage and retrieval of persisted feature flag variants for the JS-fallback
+ * implementation. Uses the AsyncStorage adapter; payloads are serialized to a
+ * string via JSON.stringify / JSON.parse.
+ */
+export class MixpanelFlagPersistence {
+  constructor(persistence, token, storage) {
+    this.persistence = persistence;
+    this.persistedVariantsKey = PERSISTED_VARIANTS_KEY_PREFIX + token;
+    this.storage = storage;
+    this.token = token;
+  }
+
+  getPolicy() {
+    if (!this._isConfigValid()) {
+      return VariantLookupPolicy.NETWORK_ONLY;
+    }
+    return this.persistence.variantLookupPolicy;
+  }
+
+  getTtlMs() {
+    if (!this._isConfigValid()) {
+      return DEFAULT_TTL_MS;
+    }
+    const configuredTtl = this.persistence.persistenceTtlMs;
+    return configuredTtl === undefined || configuredTtl === null
+      ? DEFAULT_TTL_MS
+      : configuredTtl;
+  }
+
+  _isConfigValid() {
+    const config = this.persistence;
+    if (!config) {
+      return false;
+    }
+
+    if (VALID_POLICIES.indexOf(config.variantLookupPolicy) === -1) {
+      MixpanelLogger.error(
+        this.token,
+        'Invalid variantLookupPolicy:',
+        config.variantLookupPolicy
+      );
+      return false;
+    }
+
+    if (
+      config.persistenceTtlMs !== undefined &&
+      config.persistenceTtlMs !== null &&
+      config.persistenceTtlMs <= 0
+    ) {
+      MixpanelLogger.error(
+        this.token,
+        'If provided, persistenceTtlMs must be a positive number. Provided value:',
+        config.persistenceTtlMs
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Load persisted variants if they match the current context and haven't
+   * expired. Returns `null` for any miss (no persisted blob, TTL expired,
+   * distinct_id mismatch, or unreadable storage). Stale entries are NOT
+   * auto-deleted on read — the next successful fetch overwrites them.
+   */
+  async loadFlagsFromStorage(context) {
+    if (this.getPolicy() === VariantLookupPolicy.NETWORK_ONLY) {
+      await this.clear();
+      return null;
+    }
+
+    const ttlMs = this.getTtlMs();
+    let data;
+    try {
+      const raw = await this.storage.getItem(this.persistedVariantsKey);
+      data = raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      MixpanelLogger.error(
+        this.token,
+        'Failed to load persisted variants from storage, so clearing',
+        error
+      );
+      await this.clear();
+      return null;
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    if (ttlMs && Date.now() - data.persistedAt >= ttlMs) {
+      return null;
+    }
+
+    if (!context || data.distinctId !== context.distinct_id) {
+      await this.clear();
+      return null;
+    }
+
+    const persistedFlags = new Map();
+    const flagVariants = data.flagVariants || {};
+    Object.keys(flagVariants).forEach((key) => {
+      const variantData = flagVariants[key];
+      persistedFlags.set(key, {
+        key: variantData.variant_key,
+        value: variantData.variant_value,
+        experiment_id: variantData.experiment_id,
+        is_experiment_active: variantData.is_experiment_active,
+        is_qa_tester: variantData.is_qa_tester,
+        variant_source: 'persistence',
+        persisted_at_in_ms: data.persistedAt,
+      });
+    });
+
+    return {
+      flags: persistedFlags,
+      persistedAtMs: data.persistedAt,
+      ttlMs: ttlMs,
+    };
+  }
+
+  async save(context, flagsMap) {
+    if (this.getPolicy() === VariantLookupPolicy.NETWORK_ONLY) {
+      return;
+    }
+
+    const flagVariants = {};
+    flagsMap.forEach((variant, key) => {
+      flagVariants[key] = {
+        variant_key: variant.key,
+        variant_value: variant.value,
+        experiment_id: variant.experiment_id,
+        is_experiment_active: variant.is_experiment_active,
+        is_qa_tester: variant.is_qa_tester,
+      };
+    });
+
+    const data = {
+      persistedAt: Date.now(),
+      distinctId: context && context.distinct_id,
+      context: context,
+      flagVariants: flagVariants,
+    };
+
+    try {
+      await this.storage.setItem(this.persistedVariantsKey, JSON.stringify(data));
+    } catch (error) {
+      MixpanelLogger.error(
+        this.token,
+        'Failed to persist variants to storage:',
+        error
+      );
+    }
+  }
+
+  async clear() {
+    try {
+      await this.storage.removeItem(this.persistedVariantsKey);
+    } catch (error) {
+      MixpanelLogger.error(
+        this.token,
+        'Failed to clear persisted variants from storage:',
+        error
+      );
+    }
+  }
+}
+
+export { VariantLookupPolicy, PERSISTED_VARIANTS_KEY_PREFIX, DEFAULT_TTL_MS };

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -1,4 +1,5 @@
 import { encode as base64Encode } from 'base-64';
+import jsonLogic from 'json-logic-js';
 import { MixpanelLogger } from './mixpanel-logger';
 import { MixpanelNetwork } from './mixpanel-network';
 import { MixpanelPersistent } from './mixpanel-persistent';
@@ -22,6 +23,33 @@ function withSource(variant, source, extras) {
   return stamped;
 }
 
+function getPendingEventKey(flagKey, firstTimeEventHash) {
+  return flagKey + ':' + firstTimeEventHash;
+}
+
+function getFlagKeyFromPendingEventKey(eventKey) {
+  return eventKey.split(':')[0];
+}
+
+/**
+ * Direct port of ~/mixpanel-js/src/targeting/event-matcher.js. Replaces the
+ * window.__mp_targeting bundle dance with a synchronous json-logic-js import.
+ */
+function eventMatchesCriteria(eventName, properties, criteria) {
+  if (eventName !== criteria.event_name) {
+    return { matches: false };
+  }
+  const propertyFilters = criteria.property_filters;
+  if (!propertyFilters || Object.keys(propertyFilters).length === 0) {
+    return { matches: true };
+  }
+  try {
+    return { matches: !!jsonLogic.apply(propertyFilters, properties || {}) };
+  } catch (error) {
+    return { matches: false, error: String(error) };
+  }
+}
+
 export class MixpanelFlagsJS {
   constructor(token, mixpanelImpl, storage, featureFlagsOptions = {}) {
     this.token = token;
@@ -35,6 +63,8 @@ export class MixpanelFlagsJS {
   init() {
     this.flags = null;
     this.experimentTracked = new Set();
+    this.pendingFirstTimeEvents = {};
+    this.activatedFirstTimeEvents = {};
     this._loadedPersistedAtMs = null;
     this._loadedTtlMs = null;
     this._fetchStartTime = null;
@@ -49,11 +79,18 @@ export class MixpanelFlagsJS {
       this.storage
     );
 
+    // Register a back-reference so MixpanelMain.track() can invoke
+    // checkFirstTimeEvents on every tracked event in JS-fallback mode.
+    if (this.mixpanelImpl) {
+      this.mixpanelImpl._flagsJS = this;
+    }
+
     this.persistenceLoadedPromise = this.persistence
       .loadFlagsFromStorage(this._buildContext())
       .then((loaded) => {
         if (loaded) {
           this.flags = loaded.flags;
+          this.pendingFirstTimeEvents = loaded.pendingFirstTimeEvents || {};
           this._loadedPersistedAtMs = loaded.persistedAtMs;
           this._loadedTtlMs = loaded.ttlMs;
         }
@@ -196,7 +233,27 @@ export class MixpanelFlagsJS {
           throw new Error('No flags in API response');
         }
         const flags = new Map();
+        const pendingFirstTimeEvents = {};
+
         for (const [key, data] of Object.entries(response.flags)) {
+          // If a first-time event for this flag has already been activated
+          // this session, preserve the activated variant rather than
+          // overwriting it with the server's current variant.
+          let hasActivatedEvent = false;
+          const prefix = key + ':';
+          for (const eventKey of Object.keys(this.activatedFirstTimeEvents)) {
+            if (eventKey.startsWith(prefix)) {
+              hasActivatedEvent = true;
+              break;
+            }
+          }
+          if (hasActivatedEvent) {
+            const currentFlag = this.flags && this.flags.get(key);
+            if (currentFlag) {
+              flags.set(key, currentFlag);
+              continue;
+            }
+          }
           flags.set(key, {
             key: data.variant_key,
             value: data.variant_value,
@@ -206,13 +263,50 @@ export class MixpanelFlagsJS {
             variant_source: NETWORK_SOURCE,
           });
         }
+
+        const topLevelDefinitions = response.pending_first_time_events;
+        if (Array.isArray(topLevelDefinitions)) {
+          for (const def of topLevelDefinitions) {
+            const eventKey = getPendingEventKey(
+              def.flag_key,
+              def.first_time_event_hash
+            );
+            // Skip events that have already been activated this session.
+            if (this.activatedFirstTimeEvents[eventKey]) {
+              continue;
+            }
+            pendingFirstTimeEvents[eventKey] = {
+              flag_key: def.flag_key,
+              flag_id: def.flag_id,
+              project_id: def.project_id,
+              first_time_event_hash: def.first_time_event_hash,
+              event_name: def.event_name,
+              property_filters: def.property_filters,
+              pending_variant: def.pending_variant,
+            };
+          }
+        }
+
+        // Preserve activated orphan flags whose flag_key is no longer in the
+        // server response.
+        for (const eventKey of Object.keys(this.activatedFirstTimeEvents)) {
+          if (!this.activatedFirstTimeEvents[eventKey]) continue;
+          const flagKey = getFlagKeyFromPendingEventKey(eventKey);
+          if (!flags.has(flagKey) && this.flags && this.flags.has(flagKey)) {
+            flags.set(flagKey, this.flags.get(flagKey));
+          }
+        }
+
         this.flags = flags;
         this.experimentTracked = new Set();
+        this.pendingFirstTimeEvents = pendingFirstTimeEvents;
         this._loadedPersistedAtMs = null;
         this._loadedTtlMs = null;
-        return this.persistence.save(context, this.flags).then(() => {
-          MixpanelLogger.log(this.token, 'Feature flags loaded successfully');
-        });
+        return this.persistence
+          .save(context, this.flags, this.pendingFirstTimeEvents)
+          .then(() => {
+            MixpanelLogger.log(this.token, 'Feature flags loaded successfully');
+          });
       })
       .catch((error) => {
         if (this._fetchStartTime !== null) {
@@ -462,6 +556,8 @@ export class MixpanelFlagsJS {
     this._loadedPersistedAtMs = null;
     this._loadedTtlMs = null;
     this.experimentTracked.clear();
+    this.pendingFirstTimeEvents = {};
+    this.activatedFirstTimeEvents = {};
 
     try {
       await this.loadFlags();
@@ -476,6 +572,8 @@ export class MixpanelFlagsJS {
   async reset() {
     this.flags = null;
     this.experimentTracked.clear();
+    this.pendingFirstTimeEvents = {};
+    this.activatedFirstTimeEvents = {};
     this._loadedPersistedAtMs = null;
     this._loadedTtlMs = null;
     try {
@@ -492,10 +590,135 @@ export class MixpanelFlagsJS {
       await this.persistence.clear();
       this.flags = null;
       this.experimentTracked.clear();
+      this.pendingFirstTimeEvents = {};
+      this.activatedFirstTimeEvents = {};
       this._loadedPersistedAtMs = null;
       this._loadedTtlMs = null;
     } catch (error) {
       MixpanelLogger.log(this.token, 'Error clearing flag cache:', error);
+    }
+  }
+
+  /**
+   * If a tracked event matches any pending first-time event, switch the
+   * corresponding flag to its pending variant and record the activation
+   * with the server (fire-and-forget). Synchronous because json-logic-js
+   * imports synchronously — no targeting-bundle Promise dance needed.
+   */
+  checkFirstTimeEvents(eventName, properties) {
+    if (
+      !this.pendingFirstTimeEvents ||
+      Object.keys(this.pendingFirstTimeEvents).length === 0
+    ) {
+      return;
+    }
+    this._processFirstTimeEventCheck(eventName, properties);
+  }
+
+  _processFirstTimeEventCheck(eventName, properties) {
+    for (const eventKey of Object.keys(this.pendingFirstTimeEvents)) {
+      if (this.activatedFirstTimeEvents[eventKey]) {
+        continue;
+      }
+      const pendingEvent = this.pendingFirstTimeEvents[eventKey];
+      const flagKey = pendingEvent.flag_key;
+
+      const criteria = {
+        event_name: pendingEvent.event_name,
+        property_filters: pendingEvent.property_filters,
+      };
+      const matchResult = eventMatchesCriteria(eventName, properties, criteria);
+
+      if (matchResult.error) {
+        MixpanelLogger.error(
+          this.token,
+          `Error checking first-time event for flag "${flagKey}": ${matchResult.error}`
+        );
+        continue;
+      }
+      if (!matchResult.matches) {
+        continue;
+      }
+
+      MixpanelLogger.log(
+        this.token,
+        `First-time event matched for flag "${flagKey}": ${eventName}`
+      );
+
+      const newVariant = {
+        key: pendingEvent.pending_variant.variant_key,
+        value: pendingEvent.pending_variant.variant_value,
+        experiment_id: pendingEvent.pending_variant.experiment_id,
+        is_experiment_active: pendingEvent.pending_variant.is_experiment_active,
+      };
+
+      this.flags.set(flagKey, newVariant);
+      this.experimentTracked.delete(flagKey);
+      this.activatedFirstTimeEvents[eventKey] = true;
+
+      this.recordFirstTimeEvent(
+        pendingEvent.flag_id,
+        pendingEvent.project_id,
+        pendingEvent.first_time_event_hash
+      );
+    }
+  }
+
+  getFirstTimeEventApiRoute(flagId) {
+    const serverURL =
+      this.mixpanelImpl.config?.getServerURL?.(this.token) ||
+      'https://api.mixpanel.com';
+    return `${serverURL.replace(/\/$/, '')}/flags/${flagId}/first-time-events`;
+  }
+
+  /** Fire-and-forget POST to record a first-time event activation. */
+  recordFirstTimeEvent(flagId, projectId, firstTimeEventHash) {
+    const distinctId = this.mixpanelPersistent.getDistinctId(this.token);
+
+    const searchParams = new URLSearchParams();
+    searchParams.set('mp_lib', 'react-native');
+    searchParams.set('$lib_version', packageJson.version);
+    const url = `${this.getFirstTimeEventApiRoute(flagId)}?${searchParams.toString()}`;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${base64Encode(this.token + ':')}`,
+    };
+    if (this._traceparent) {
+      headers.traceparent = this._traceparent;
+    }
+
+    const payload = {
+      distinct_id: distinctId,
+      project_id: projectId,
+      first_time_event_hash: firstTimeEventHash,
+    };
+
+    MixpanelLogger.log(this.token, `Recording first-time event for flag: ${flagId}`);
+
+    // Direct fetch (not MixpanelNetwork) mirrors mixpanel-js: fire-and-forget
+    // with no retries, raw JSON body. Swallow errors — cohort sync catches up.
+    try {
+      const promise = fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      });
+      if (promise && typeof promise.catch === 'function') {
+        promise.catch((error) => {
+          MixpanelLogger.error(
+            this.token,
+            `Failed to record first-time event for flag ${flagId}:`,
+            error
+          );
+        });
+      }
+    } catch (error) {
+      MixpanelLogger.error(
+        this.token,
+        `Failed to record first-time event for flag ${flagId}:`,
+        error
+      );
     }
   }
 
@@ -546,5 +769,9 @@ export class MixpanelFlagsJS {
 
   update_context(newContext, options) {
     return this.updateContext(newContext, options);
+  }
+
+  check_first_time_events(eventName, properties) {
+    return this.checkFirstTimeEvents(eventName, properties);
   }
 }

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -656,6 +656,8 @@ export class MixpanelFlagsJS {
         value: pendingEvent.pending_variant.variant_value,
         experiment_id: pendingEvent.pending_variant.experiment_id,
         is_experiment_active: pendingEvent.pending_variant.is_experiment_active,
+        is_qa_tester: pendingEvent.pending_variant.is_qa_tester,
+        variant_source: NETWORK_SOURCE,
       };
 
       this.flags.set(flagKey, newVariant);

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -216,6 +216,11 @@ export class MixpanelFlagsJS {
       headers: authHeaders,
     })
       .then((response) => {
+        // Abandoned by _invalidateInFlightFetch() (reset/updateContext/
+        // identify). Discard so this fetch can't overwrite fresh state.
+        if (this._fetchStartTime === null) {
+          return;
+        }
         this.markFetchComplete();
 
         if (!response || !response.flags) {
@@ -309,6 +314,7 @@ export class MixpanelFlagsJS {
   }
 
   areFlagsReady() {
+    if (this._loadedPersistenceIsStale()) return false;
     return !!this.flags;
   }
 

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -207,7 +207,7 @@ export class MixpanelFlagsJS {
       authHeaders.traceparent = this._traceparent;
     }
 
-    this.fetchPromise = MixpanelNetwork.sendRequest({
+    const myPromise = MixpanelNetwork.sendRequest({
       token: this.token,
       endpoint: endpoint,
       data: null,
@@ -216,9 +216,15 @@ export class MixpanelFlagsJS {
       headers: authHeaders,
     })
       .then((response) => {
-        // Abandoned by _invalidateInFlightFetch() (reset/updateContext/
-        // identify). Discard so this fetch can't overwrite fresh state.
-        if (this._fetchStartTime === null) {
+        // Guard by promise identity so a fetch abandoned by
+        // _invalidateInFlightFetch() (reset/updateContext/identify) can't
+        // install its stale result, even after a replacement fetch is in
+        // flight or has completed.
+        if (this.fetchPromise !== myPromise) {
+          MixpanelLogger.log(
+            this.token,
+            'Fetch was superseded and is not stale. Ignoring result'
+          );
           return;
         }
         this.markFetchComplete();
@@ -303,28 +309,25 @@ export class MixpanelFlagsJS {
           });
       })
       .catch((error) => {
-        if (this._fetchStartTime !== null) {
-          this.markFetchComplete();
+        if (this.fetchPromise !== myPromise) {
+          MixpanelLogger.log(
+            this.token,
+            'Fetch was superseded and is not stale. Ignoring result'
+          );
+          return;
         }
+        this.markFetchComplete();
         MixpanelLogger.log(this.token, 'Error loading feature flags:', error);
         throw error;
       });
 
-    return this.fetchPromise;
+    this.fetchPromise = myPromise;
+    return myPromise;
   }
 
   areFlagsReady() {
     if (this._loadedPersistenceIsStale()) return false;
     return !!this.flags;
-  }
-
-  /**
-   * Resolves with the current in-flight fetch (if one is running) or
-   * immediately with the current state.
-   */
-  whenReady() {
-    if (this.fetchPromise) return this.fetchPromise;
-    return Promise.resolve();
   }
 
   /**
@@ -764,10 +767,6 @@ export class MixpanelFlagsJS {
 
   load_flags() {
     return this.loadFlags();
-  }
-
-  when_ready() {
-    return this.whenReady();
   }
 
   update_context(newContext, options) {

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -538,6 +538,10 @@ export class MixpanelFlagsJS {
     this.pendingFirstTimeEvents = {};
     this.activatedFirstTimeEvents = {};
 
+    // Any in-flight fetch was built under the previous context; discard it so
+    // loadFlags() below issues a fresh request under the updated context.
+    this._invalidateInFlightFetch();
+
     try {
       await this.loadFlags();
     } catch (error) {

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -13,10 +13,10 @@ const NETWORK_SOURCE = 'network';
 const FALLBACK_SOURCE = 'fallback';
 
 function withSource(variant, source, extras) {
-  if (!variant || typeof variant !== 'object') {
-    return variant;
-  }
-  const stamped = { ...variant, variant_source: source };
+  const stamped =
+    variant !== null && typeof variant === 'object'
+      ? { ...variant, variant_source: source }
+      : { value: variant, variant_source: source };
   if (extras) {
     Object.assign(stamped, extras);
   }
@@ -97,7 +97,7 @@ export class MixpanelFlagsJS {
       });
 
     return this.persistenceLoadedPromise
-      .then(() => this.fetchFlags())
+      .then(() => this.loadFlags())
       .catch((error) => {
         MixpanelLogger.log(
           this.token,
@@ -123,34 +123,14 @@ export class MixpanelFlagsJS {
   }
 
   /**
-   * Generate W3C traceparent header. Format: 00-{traceID}-{parentID}-{flags}
-   * Returns null if UUID generation fails (graceful degradation).
+   * Generate W3C traceparent header. Format: 00-{traceID}-{parentID}-{flags}.
+   * Callers wrap in try/catch; this method does not — failures bubble.
    */
   generateTraceparent() {
-    try {
-      // Try expo-crypto first
-      const crypto = require('expo-crypto');
-      const traceID = crypto.randomUUID().replace(/-/g, '');
-      const parentID = crypto.randomUUID().replace(/-/g, '').substring(0, 16);
-      return `00-${traceID}-${parentID}-01`;
-    } catch (expoCryptoError) {
-      try {
-        // Fallback to uuid (import the v4 function directly)
-        const { v4: uuidv4 } = require('uuid');
-        const traceID = uuidv4().replace(/-/g, '');
-        const parentID = uuidv4().replace(/-/g, '').substring(0, 16);
-        return `00-${traceID}-${parentID}-01`;
-      } catch (uuidError) {
-        // Graceful degradation: traceparent is optional for observability
-        // Don't block flag loading if UUID generation fails
-        MixpanelLogger.log(
-          this.token,
-          'Could not generate traceparent (UUID unavailable):',
-          uuidError
-        );
-        return null;
-      }
-    }
+    const uuidv4 = require('uuid/v4');
+    const traceID = uuidv4().replace(/-/g, '');
+    const parentID = uuidv4().replace(/-/g, '').substring(0, 16);
+    return `00-${traceID}-${parentID}-01`;
   }
 
   markFetchComplete() {
@@ -344,27 +324,26 @@ export class MixpanelFlagsJS {
     this.experimentTracked.add(featureName);
 
     try {
+      const fetchStartTime =
+        this._fetchCompleteTime != null
+          ? this._fetchCompleteTime - (this._fetchLatency || 0)
+          : null;
       const properties = {
         'Experiment name': featureName,
         'Variant name': variant.key,
         $experiment_type: 'feature_flag',
+        'Variant fetch start time':
+          fetchStartTime != null
+            ? new Date(fetchStartTime).toISOString()
+            : null,
+        'Variant fetch complete time':
+          this._fetchCompleteTime != null
+            ? new Date(this._fetchCompleteTime).toISOString()
+            : null,
+        'Variant fetch latency (ms)':
+          this._fetchLatency != null ? this._fetchLatency : null,
+        'Variant fetch traceparent': this._traceparent || null,
       };
-
-      if (this._fetchCompleteTime) {
-        const fetchStartTime =
-          this._fetchCompleteTime - (this._fetchLatency || 0);
-        properties['Variant fetch start time'] = new Date(
-          fetchStartTime
-        ).toISOString();
-        properties['Variant fetch complete time'] = new Date(
-          this._fetchCompleteTime
-        ).toISOString();
-        properties['Variant fetch latency (ms)'] = this._fetchLatency || 0;
-      }
-
-      if (this._traceparent) {
-        properties['Variant fetch traceparent'] = this._traceparent;
-      }
 
       if (
         variant.experiment_id !== undefined &&
@@ -568,6 +547,16 @@ export class MixpanelFlagsJS {
     MixpanelLogger.log(this.token, 'Context updated, flags reloaded');
   }
 
+  /**
+   * Discard any in-flight fetch so subsequent loadFlags() starts fresh under
+   * the current identity. Used by reset() and by identify() flows that need
+   * to abandon a fetch keyed under a stale identity.
+   */
+  _invalidateInFlightFetch() {
+    this.fetchPromise = null;
+    this._fetchStartTime = null;
+  }
+
   /** Clear all flag state and trigger a fresh fetch under the new identity. */
   async reset() {
     this.flags = null;
@@ -576,26 +565,12 @@ export class MixpanelFlagsJS {
     this.activatedFirstTimeEvents = {};
     this._loadedPersistedAtMs = null;
     this._loadedTtlMs = null;
+    this._invalidateInFlightFetch();
     try {
       await this.persistence.clear();
       await this.loadFlags();
     } catch (error) {
       MixpanelLogger.log(this.token, 'Error during flags reset:', error);
-    }
-  }
-
-  /** Discard in-memory and persisted variants. */
-  async clearCache() {
-    try {
-      await this.persistence.clear();
-      this.flags = null;
-      this.experimentTracked.clear();
-      this.pendingFirstTimeEvents = {};
-      this.activatedFirstTimeEvents = {};
-      this._loadedPersistedAtMs = null;
-      this._loadedTtlMs = null;
-    } catch (error) {
-      MixpanelLogger.log(this.token, 'Error clearing flag cache:', error);
     }
   }
 

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -207,6 +207,7 @@ export class MixpanelFlagsJS {
           });
         }
         this.flags = flags;
+        this.experimentTracked = new Set();
         this._loadedPersistedAtMs = null;
         this._loadedTtlMs = null;
         return this.persistence.save(context, this.flags).then(() => {
@@ -246,6 +247,7 @@ export class MixpanelFlagsJS {
     if (this.experimentTracked.has(featureName)) {
       return;
     }
+    this.experimentTracked.add(featureName);
 
     try {
       const properties = {
@@ -306,8 +308,8 @@ export class MixpanelFlagsJS {
         '$experiment_started',
         properties
       );
-      this.experimentTracked.add(featureName);
     } catch (error) {
+      this.experimentTracked.delete(featureName);
       MixpanelLogger.log(this.token, 'Error tracking experiment:', error);
     }
   }
@@ -368,32 +370,22 @@ export class MixpanelFlagsJS {
     await this.persistenceLoadedPromise;
 
     const policy = this.persistence.getPolicy();
-    if (policy === VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS) {
-      if (this.areFlagsReady() && !this._loadedPersistenceIsStale()) {
-        return this.getVariantSync(featureName, fallback);
-      }
-      if (!this.fetchPromise) {
-        return withSource(fallback, FALLBACK_SOURCE);
-      }
-      try {
-        await this.fetchPromise;
-        return this.getVariantSync(featureName, fallback);
-      } catch (error) {
-        MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
-        return withSource(fallback, FALLBACK_SOURCE);
-      }
+    if (
+      policy === VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS &&
+      this.areFlagsReady() &&
+      !this._loadedPersistenceIsStale()
+    ) {
+      return this.getVariantSync(featureName, fallback);
     }
 
-    if (!this.fetchPromise) {
-      return withSource(fallback, FALLBACK_SOURCE);
+    if (this.fetchPromise) {
+      try {
+        await this.fetchPromise;
+      } catch (error) {
+        MixpanelLogger.log(this.token, 'Error awaiting fetch:', error);
+      }
     }
-    try {
-      await this.fetchPromise;
-      return this.getVariantSync(featureName, fallback);
-    } catch (error) {
-      MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
-      return withSource(fallback, FALLBACK_SOURCE);
-    }
+    return this.getVariantSync(featureName, fallback);
   }
 
   async getVariantValue(featureName, fallbackValue) {
@@ -420,55 +412,37 @@ export class MixpanelFlagsJS {
   async getAllVariants() {
     if (!this.persistenceLoadedPromise) {
       MixpanelLogger.error(this.token, 'Feature Flags not initialized');
-      return {};
+      return new Map();
     }
     await this.persistenceLoadedPromise;
 
     const policy = this.persistence.getPolicy();
-    if (policy === VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS) {
-      if (this.areFlagsReady() && !this._loadedPersistenceIsStale()) {
-        return this.getAllVariantsSync();
-      }
-      if (!this.fetchPromise) {
-        return {};
-      }
-      try {
-        await this.fetchPromise;
-        return this.getAllVariantsSync();
-      } catch (error) {
-        MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
-        return {};
-      }
+    if (
+      policy === VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS &&
+      this.areFlagsReady() &&
+      !this._loadedPersistenceIsStale()
+    ) {
+      return this.getAllVariantsSync();
     }
 
-    if (!this.fetchPromise) {
-      return {};
+    if (this.fetchPromise) {
+      try {
+        await this.fetchPromise;
+      } catch (error) {
+        MixpanelLogger.log(this.token, 'Error awaiting fetch:', error);
+      }
     }
-    try {
-      await this.fetchPromise;
-      return this.getAllVariantsSync();
-    } catch (error) {
-      MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
-      return {};
-    }
+    return this.getAllVariantsSync();
   }
 
   getAllVariantsSync() {
     if (this._loadedPersistenceIsStale()) {
-      return {};
+      return new Map();
     }
     if (!this.areFlagsReady()) {
-      return {};
+      return new Map();
     }
-    return this._snapshotFlags();
-  }
-
-  _snapshotFlags() {
-    const out = {};
-    this.flags.forEach((variant, key) => {
-      out[key] = variant;
-    });
-    return out;
+    return new Map(this.flags);
   }
 
   /**

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -12,15 +12,24 @@ import packageJson from 'mixpanel-react-native/package.json';
 const NETWORK_SOURCE = 'network';
 const FALLBACK_SOURCE = 'fallback';
 
-function withSource(variant, source, extras) {
-  const stamped =
-    variant !== null && typeof variant === 'object'
-      ? { ...variant, variant_source: source }
-      : { value: variant, variant_source: source };
-  if (extras) {
-    Object.assign(stamped, extras);
+// Fallback reasons surfaced via a NEW `fallback_reason` field on the returned
+// variant. `variant_source` stays as the coarse 'network' | 'persistence' |
+// 'fallback' values — adding a sibling field rather than extending the
+// existing one keeps every consumer of the published type working unchanged.
+// Values match mixpanel-js so the OpenFeature wrapper dispatch is consistent
+// across SDKs.
+const FALLBACK_REASON_FLAG_NOT_FOUND = 'FLAG_NOT_FOUND';
+const FALLBACK_REASON_NOT_READY = 'NOT_READY';
+const FALLBACK_REASON_BACKEND_ERROR = 'BACKEND_ERROR';
+
+function withSource(variant, source, reason) {
+  const extras = { variant_source: source };
+  if (reason) {
+    extras.fallback_reason = reason;
   }
-  return stamped;
+  return variant !== null && typeof variant === 'object'
+    ? { ...variant, ...extras }
+    : { value: variant, ...extras };
 }
 
 function getPendingEventKey(flagKey, firstTimeEventHash) {
@@ -393,15 +402,15 @@ export class MixpanelFlagsJS {
         this.token,
         `Loaded persisted variants are past TTL so returning fallback for "${featureName}"`
       );
-      return withSource(fallback, FALLBACK_SOURCE);
+      return withSource(fallback, FALLBACK_SOURCE, FALLBACK_REASON_NOT_READY);
     }
     if (!this.areFlagsReady()) {
       MixpanelLogger.log(this.token, 'Flags not loaded yet');
-      return withSource(fallback, FALLBACK_SOURCE);
+      return withSource(fallback, FALLBACK_SOURCE, FALLBACK_REASON_NOT_READY);
     }
     if (!this.flags.has(featureName)) {
       MixpanelLogger.log(this.token, `No flag found: "${featureName}"`);
-      return withSource(fallback, FALLBACK_SOURCE);
+      return withSource(fallback, FALLBACK_SOURCE, FALLBACK_REASON_FLAG_NOT_FOUND);
     }
 
     const variant = this.flags.get(featureName);
@@ -438,7 +447,7 @@ export class MixpanelFlagsJS {
   async getVariant(featureName, fallback) {
     if (!this.persistenceLoadedPromise) {
       MixpanelLogger.error(this.token, 'Feature Flags not initialized');
-      return withSource(fallback, FALLBACK_SOURCE);
+      return withSource(fallback, FALLBACK_SOURCE, FALLBACK_REASON_NOT_READY);
     }
     await this.persistenceLoadedPromise;
 
@@ -454,11 +463,20 @@ export class MixpanelFlagsJS {
     if (this.fetchPromise) {
       try {
         await this.fetchPromise;
+        return this.getVariantSync(featureName, fallback);
       } catch (error) {
         MixpanelLogger.log(this.token, 'Error awaiting fetch:', error);
+        // If the fetch failure still left usable state (e.g. persistence hit
+        // under a different policy), serve from cache. Otherwise stamp
+        // BACKEND_ERROR so callers can distinguish "backend is down" from
+        // "flags never loaded".
+        return this.areFlagsReady()
+          ? this.getVariantSync(featureName, fallback)
+          : withSource(fallback, FALLBACK_SOURCE, FALLBACK_REASON_BACKEND_ERROR);
       }
     }
-    return this.getVariantSync(featureName, fallback);
+    // No fetch in flight and no ready state to serve from.
+    return withSource(fallback, FALLBACK_SOURCE, FALLBACK_REASON_NOT_READY);
   }
 
   async getVariantValue(featureName, fallbackValue) {

--- a/javascript/mixpanel-flags-js.js
+++ b/javascript/mixpanel-flags-js.js
@@ -1,100 +1,114 @@
-import { MixpanelLogger } from "./mixpanel-logger";
-import { MixpanelNetwork } from "./mixpanel-network";
-import { MixpanelPersistent } from "./mixpanel-persistent";
-import packageJson from "mixpanel-react-native/package.json";
+import { encode as base64Encode } from 'base-64';
+import { MixpanelLogger } from './mixpanel-logger';
+import { MixpanelNetwork } from './mixpanel-network';
+import { MixpanelPersistent } from './mixpanel-persistent';
+import {
+  MixpanelFlagPersistence,
+  VariantLookupPolicy,
+} from './mixpanel-flag-persistence';
+import packageJson from 'mixpanel-react-native/package.json';
 
-/**
- * JavaScript implementation of Feature Flags for React Native
- * This is used when native modules are not available (Expo, React Native Web)
- * Aligned with mixpanel-js reference implementation
- */
+const NETWORK_SOURCE = 'network';
+const FALLBACK_SOURCE = 'fallback';
+
+function withSource(variant, source, extras) {
+  if (!variant || typeof variant !== 'object') {
+    return variant;
+  }
+  const stamped = { ...variant, variant_source: source };
+  if (extras) {
+    Object.assign(stamped, extras);
+  }
+  return stamped;
+}
+
 export class MixpanelFlagsJS {
-  constructor(token, mixpanelImpl, storage, initialContext = {}) {
+  constructor(token, mixpanelImpl, storage, featureFlagsOptions = {}) {
     this.token = token;
     this.mixpanelImpl = mixpanelImpl;
     this.storage = storage;
-    this.flags = new Map(); // Use Map like mixpanel-js
-    this.flagsReady = false;
-    this.experimentTracked = new Set();
-    this.context = initialContext; // Initialize with provided context
-    this.flagsCacheKey = `MIXPANEL_${token}_FLAGS_CACHE`;
-    this.flagsReadyKey = `MIXPANEL_${token}_FLAGS_READY`;
+    this.featureFlagsOptions = featureFlagsOptions || {};
+    this.context = this.featureFlagsOptions.context || {};
     this.mixpanelPersistent = MixpanelPersistent.getInstance(storage, token);
+  }
 
-    // Performance tracking (mixpanel-js alignment)
+  init() {
+    this.flags = null;
+    this.experimentTracked = new Set();
+    this._loadedPersistedAtMs = null;
+    this._loadedTtlMs = null;
     this._fetchStartTime = null;
     this._fetchCompleteTime = null;
     this._fetchLatency = null;
     this._traceparent = null;
+    this.fetchPromise = null;
 
-    // Load cached flags on initialization (fire and forget - loads in background)
-    // This is async but intentionally not awaited to avoid blocking constructor
-    // Flags will be available once cache loads or after explicit loadFlags() call
-    this.loadCachedFlags().catch(error => {
-      MixpanelLogger.log(this.token, "Failed to load cached flags in constructor:", error);
-    });
+    this.persistence = new MixpanelFlagPersistence(
+      this.featureFlagsOptions.persistence,
+      this.token,
+      this.storage
+    );
+
+    this.persistenceLoadedPromise = this.persistence
+      .loadFlagsFromStorage(this._buildContext())
+      .then((loaded) => {
+        if (loaded) {
+          this.flags = loaded.flags;
+          this._loadedPersistedAtMs = loaded.persistedAtMs;
+          this._loadedTtlMs = loaded.ttlMs;
+        }
+      });
+
+    return this.persistenceLoadedPromise
+      .then(() => this.fetchFlags())
+      .catch((error) => {
+        MixpanelLogger.log(
+          this.token,
+          'Error initializing feature flags:',
+          error
+        );
+      });
   }
 
-  /**
-   * Load cached flags from storage
-   */
-  async loadCachedFlags() {
-    try {
-      const cachedFlags = await this.storage.getItem(this.flagsCacheKey);
-      if (cachedFlags) {
-        const parsed = JSON.parse(cachedFlags);
-        // Convert array back to Map for consistency
-        this.flags = new Map(parsed);
-        this.flagsReady = true;
-        MixpanelLogger.log(this.token, "Loaded cached feature flags");
-      }
-    } catch (error) {
-      MixpanelLogger.log(this.token, "Error loading cached flags:", error);
+  _buildContext() {
+    return {
+      distinct_id: this.mixpanelPersistent.getDistinctId(this.token),
+      device_id: this.mixpanelPersistent.getDeviceId(this.token),
+      ...this.context,
+    };
+  }
+
+  _loadedPersistenceIsStale() {
+    if (this._loadedPersistedAtMs === null || !this._loadedTtlMs) {
+      return false;
     }
+    return Date.now() - this._loadedPersistedAtMs >= this._loadedTtlMs;
   }
 
   /**
-   * Cache flags to storage
-   */
-  async cacheFlags() {
-    try {
-      // Convert Map to array for JSON serialization
-      const flagsArray = Array.from(this.flags.entries());
-      await this.storage.setItem(
-        this.flagsCacheKey,
-        JSON.stringify(flagsArray)
-      );
-      await this.storage.setItem(this.flagsReadyKey, "true");
-    } catch (error) {
-      MixpanelLogger.log(this.token, "Error caching flags:", error);
-    }
-  }
-
-  /**
-   * Generate W3C traceparent header
-   * Format: 00-{traceID}-{parentID}-{flags}
-   * Returns null if UUID generation fails (graceful degradation)
+   * Generate W3C traceparent header. Format: 00-{traceID}-{parentID}-{flags}
+   * Returns null if UUID generation fails (graceful degradation).
    */
   generateTraceparent() {
     try {
       // Try expo-crypto first
-      const crypto = require("expo-crypto");
-      const traceID = crypto.randomUUID().replace(/-/g, "");
-      const parentID = crypto.randomUUID().replace(/-/g, "").substring(0, 16);
+      const crypto = require('expo-crypto');
+      const traceID = crypto.randomUUID().replace(/-/g, '');
+      const parentID = crypto.randomUUID().replace(/-/g, '').substring(0, 16);
       return `00-${traceID}-${parentID}-01`;
     } catch (expoCryptoError) {
       try {
         // Fallback to uuid (import the v4 function directly)
-        const { v4: uuidv4 } = require("uuid");
-        const traceID = uuidv4().replace(/-/g, "");
-        const parentID = uuidv4().replace(/-/g, "").substring(0, 16);
+        const { v4: uuidv4 } = require('uuid');
+        const traceID = uuidv4().replace(/-/g, '');
+        const parentID = uuidv4().replace(/-/g, '').substring(0, 16);
         return `00-${traceID}-${parentID}-01`;
       } catch (uuidError) {
         // Graceful degradation: traceparent is optional for observability
         // Don't block flag loading if UUID generation fails
         MixpanelLogger.log(
           this.token,
-          "Could not generate traceparent (UUID unavailable):",
+          'Could not generate traceparent (UUID unavailable):',
           uuidError
         );
         return null;
@@ -102,14 +116,11 @@ export class MixpanelFlagsJS {
     }
   }
 
-  /**
-   * Mark fetch operation complete and calculate latency
-   */
   markFetchComplete() {
     if (!this._fetchStartTime) {
       MixpanelLogger.error(
         this.token,
-        "Fetch start time not set, cannot mark fetch complete"
+        'Fetch start time not set, cannot mark fetch complete'
       );
       return;
     }
@@ -118,10 +129,18 @@ export class MixpanelFlagsJS {
     this._fetchStartTime = null;
   }
 
-  /**
-   * Fetch feature flags from Mixpanel API
-   */
-  async loadFlags() {
+  loadFlags() {
+    if (!this.persistence) {
+      MixpanelLogger.error(this.token, 'loadFlags called before init');
+      return Promise.resolve();
+    }
+    if (this._fetchStartTime !== null) {
+      return this.fetchPromise;
+    }
+    return this.fetchFlags();
+  }
+
+  fetchFlags() {
     this._fetchStartTime = Date.now();
 
     // Generate traceparent if possible (graceful degradation if UUID unavailable)
@@ -132,187 +151,195 @@ export class MixpanelFlagsJS {
       this._traceparent = null;
     }
 
-    try {
-      const distinctId = this.mixpanelPersistent.getDistinctId(this.token);
-      const deviceId = this.mixpanelPersistent.getDeviceId(this.token);
+    const context = this._buildContext();
 
-      // Build context object (mixpanel-js format)
-      const context = {
-        distinct_id: distinctId,
-        device_id: deviceId,
-        ...this.context,
-      };
+    // Build query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.set('context', JSON.stringify(context));
+    queryParams.set('token', this.token);
+    queryParams.set('mp_lib', 'react-native');
+    queryParams.set('$lib_version', packageJson.version);
 
-      // Build query parameters (mixpanel-js format)
-      const queryParams = new URLSearchParams();
-      queryParams.set('context', JSON.stringify(context));
-      queryParams.set('token', this.token);
-      queryParams.set('mp_lib', 'react-native');
-      queryParams.set('$lib_version', packageJson.version);
+    MixpanelLogger.log(
+      this.token,
+      'Fetching feature flags with context:',
+      context
+    );
 
-      MixpanelLogger.log(
-        this.token,
-        "Fetching feature flags with context:",
-        context
-      );
+    const serverURL =
+      this.mixpanelImpl.config?.getServerURL?.(this.token) ||
+      'https://api.mixpanel.com';
 
-      const serverURL =
-        this.mixpanelImpl.config?.getServerURL?.(this.token) ||
-        "https://api.mixpanel.com";
+    // Use /flags endpoint with query parameters
+    const endpoint = `/flags?${queryParams.toString()}`;
 
-      // Use /flags endpoint with query parameters (mixpanel-js format)
-      const endpoint = `/flags?${queryParams.toString()}`;
+    // HTTP Basic with the project token as the username and an empty password.
+    const authHeaders = {
+      Authorization: `Basic ${base64Encode(this.token + ':')}`,
+    };
+    if (this._traceparent) {
+      authHeaders.traceparent = this._traceparent;
+    }
 
-      const response = await MixpanelNetwork.sendRequest({
-        token: this.token,
-        endpoint: endpoint,
-        data: null, // Data is in query params for flags endpoint
-        serverURL: serverURL,
-        useIPAddressForGeoLocation: true,
-      });
+    this.fetchPromise = MixpanelNetwork.sendRequest({
+      token: this.token,
+      endpoint: endpoint,
+      data: null,
+      serverURL: serverURL,
+      useIPAddressForGeoLocation: true,
+      headers: authHeaders,
+    })
+      .then((response) => {
+        this.markFetchComplete();
 
-      this.markFetchComplete();
-
-      // Support both response formats for backwards compatibility
-      if (response && response.flags) {
-        // New format (mixpanel-js compatible): {flags: {key: {variant_key, variant_value, ...}}}
-        this.flags = new Map();
+        if (!response || !response.flags) {
+          throw new Error('No flags in API response');
+        }
+        const flags = new Map();
         for (const [key, data] of Object.entries(response.flags)) {
-          this.flags.set(key, {
+          flags.set(key, {
             key: data.variant_key,
             value: data.variant_value,
             experiment_id: data.experiment_id,
             is_experiment_active: data.is_experiment_active,
             is_qa_tester: data.is_qa_tester,
+            variant_source: NETWORK_SOURCE,
           });
         }
-        this.flagsReady = true;
-        await this.cacheFlags();
-        MixpanelLogger.log(this.token, "Feature flags loaded successfully");
-      } else if (response && response.featureFlags) {
-        // Legacy format: {featureFlags: [{key, value, experimentID, ...}]}
-        this.flags = new Map();
-        for (const flag of response.featureFlags) {
-          this.flags.set(flag.key, {
-            key: flag.key,
-            value: flag.value,
-            experiment_id: flag.experimentID,
-            is_experiment_active: flag.isExperimentActive,
-            is_qa_tester: flag.isQATester,
-          });
+        this.flags = flags;
+        this._loadedPersistedAtMs = null;
+        this._loadedTtlMs = null;
+        return this.persistence.save(context, this.flags).then(() => {
+          MixpanelLogger.log(this.token, 'Feature flags loaded successfully');
+        });
+      })
+      .catch((error) => {
+        if (this._fetchStartTime !== null) {
+          this.markFetchComplete();
         }
-        this.flagsReady = true;
-        await this.cacheFlags();
-        MixpanelLogger.warn(
-          this.token,
-          'Received legacy featureFlags format. Please update backend to use "flags" format.'
-        );
-      }
-    } catch (error) {
-      this.markFetchComplete();
-      MixpanelLogger.log(this.token, "Error loading feature flags:", error);
-      // Keep using cached flags if available
-      if (this.flags.size > 0) {
-        this.flagsReady = true;
-      }
-    }
+        MixpanelLogger.log(this.token, 'Error loading feature flags:', error);
+        throw error;
+      });
+
+    return this.fetchPromise;
   }
 
-  /**
-   * Check if flags are ready to use
-   */
   areFlagsReady() {
-    return this.flagsReady;
+    return !!this.flags;
   }
 
   /**
-   * Track experiment started event
-   * Aligned with mixpanel-js tracking properties
+   * Resolves with the current in-flight fetch (if one is running) or
+   * immediately with the current state.
+   */
+  whenReady() {
+    if (this.fetchPromise) return this.fetchPromise;
+    return Promise.resolve();
+  }
+
+  /**
+   * Track $experiment_started for a feature on first access. Includes
+   * $variant_source so analytics can distinguish network-served from
+   * persistence-served evaluations.
    */
   async trackExperimentStarted(featureName, variant) {
     if (this.experimentTracked.has(featureName)) {
-      return; // Already tracked
+      return;
     }
 
     try {
       const properties = {
-        "Experiment name": featureName, // Human-readable (mixpanel-js format)
-        "Variant name": variant.key, // Human-readable (mixpanel-js format)
-        $experiment_type: "feature_flag", // Added to match mixpanel-js
+        'Experiment name': featureName,
+        'Variant name': variant.key,
+        $experiment_type: 'feature_flag',
       };
 
-      // Add performance metrics if available
       if (this._fetchCompleteTime) {
         const fetchStartTime =
           this._fetchCompleteTime - (this._fetchLatency || 0);
-        properties["Variant fetch start time"] = new Date(
+        properties['Variant fetch start time'] = new Date(
           fetchStartTime
         ).toISOString();
-        properties["Variant fetch complete time"] = new Date(
+        properties['Variant fetch complete time'] = new Date(
           this._fetchCompleteTime
         ).toISOString();
-        properties["Variant fetch latency (ms)"] = this._fetchLatency || 0;
+        properties['Variant fetch latency (ms)'] = this._fetchLatency || 0;
       }
 
-      // Add traceparent if available
       if (this._traceparent) {
-        properties["Variant fetch traceparent"] = this._traceparent;
+        properties['Variant fetch traceparent'] = this._traceparent;
       }
 
-      // Add experiment metadata (system properties)
       if (
         variant.experiment_id !== undefined &&
         variant.experiment_id !== null
       ) {
-        properties["$experiment_id"] = variant.experiment_id;
+        properties['$experiment_id'] = variant.experiment_id;
       }
-      if (variant.is_experiment_active !== undefined) {
-        properties["$is_experiment_active"] = variant.is_experiment_active;
+      if (
+        variant.is_experiment_active !== undefined &&
+        variant.is_experiment_active !== null
+      ) {
+        properties['$is_experiment_active'] = variant.is_experiment_active;
       }
-      if (variant.is_qa_tester !== undefined) {
-        properties["$is_qa_tester"] = variant.is_qa_tester;
+      if (
+        variant.is_qa_tester !== undefined &&
+        variant.is_qa_tester !== null
+      ) {
+        properties['$is_qa_tester'] = variant.is_qa_tester;
+      }
+      if (
+        variant.variant_source !== undefined &&
+        variant.variant_source !== null
+      ) {
+        properties['$variant_source'] = variant.variant_source;
+      }
+      if (
+        variant.persisted_at_in_ms !== undefined &&
+        variant.persisted_at_in_ms !== null
+      ) {
+        properties['$persisted_at_in_ms'] = variant.persisted_at_in_ms;
       }
 
-      // Track the experiment started event
       await this.mixpanelImpl.track(
         this.token,
-        "$experiment_started",
+        '$experiment_started',
         properties
       );
       this.experimentTracked.add(featureName);
-
-      MixpanelLogger.log(
-        this.token,
-        `Tracked experiment started for ${featureName}`
-      );
     } catch (error) {
-      MixpanelLogger.log(this.token, "Error tracking experiment:", error);
+      MixpanelLogger.log(this.token, 'Error tracking experiment:', error);
     }
   }
 
-  /**
-   * Get variant synchronously (only works when flags are ready)
-   */
   getVariantSync(featureName, fallback) {
-    if (!this.flagsReady || !this.flags.has(featureName)) {
-      return fallback;
+    if (this._loadedPersistenceIsStale()) {
+      MixpanelLogger.log(
+        this.token,
+        `Loaded persisted variants are past TTL so returning fallback for "${featureName}"`
+      );
+      return withSource(fallback, FALLBACK_SOURCE);
+    }
+    if (!this.areFlagsReady()) {
+      MixpanelLogger.log(this.token, 'Flags not loaded yet');
+      return withSource(fallback, FALLBACK_SOURCE);
+    }
+    if (!this.flags.has(featureName)) {
+      MixpanelLogger.log(this.token, `No flag found: "${featureName}"`);
+      return withSource(fallback, FALLBACK_SOURCE);
     }
 
     const variant = this.flags.get(featureName);
-
-    // Track experiment on first access (fire and forget)
-    if (!this.experimentTracked.has(featureName)) {
-      this.trackExperimentStarted(featureName, variant).catch(error => {
-        MixpanelLogger.warn(this.token, `Failed to track experiment for ${featureName}:`, error);
-      });
-    }
-
+    this.trackExperimentStarted(featureName, variant).catch((error) => {
+      MixpanelLogger.warn(
+        this.token,
+        `Failed to track experiment for ${featureName}:`,
+        error
+      );
+    });
     return variant;
   }
 
-  /**
-   * Get variant value synchronously
-   */
   getVariantValueSync(featureName, fallbackValue) {
     const variant = this.getVariantSync(featureName, {
       key: featureName,
@@ -321,14 +348,8 @@ export class MixpanelFlagsJS {
     return variant.value;
   }
 
-  /**
-   * Check if feature is enabled synchronously
-   * Enhanced with boolean validation like mixpanel-js
-   */
   isEnabledSync(featureName, fallbackValue = false) {
     const value = this.getVariantValueSync(featureName, fallbackValue);
-
-    // Validate boolean type (mixpanel-js pattern)
     if (value !== true && value !== false) {
       MixpanelLogger.error(
         this.token,
@@ -336,36 +357,45 @@ export class MixpanelFlagsJS {
       );
       return fallbackValue;
     }
-
     return value;
   }
 
-  /**
-   * Get variant asynchronously
-   */
   async getVariant(featureName, fallback) {
-    // If flags not ready, try to load them
-    if (!this.flagsReady) {
-      await this.loadFlags();
+    if (!this.persistenceLoadedPromise) {
+      MixpanelLogger.error(this.token, 'Feature Flags not initialized');
+      return withSource(fallback, FALLBACK_SOURCE);
+    }
+    await this.persistenceLoadedPromise;
+
+    const policy = this.persistence.getPolicy();
+    if (policy === VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS) {
+      if (this.areFlagsReady() && !this._loadedPersistenceIsStale()) {
+        return this.getVariantSync(featureName, fallback);
+      }
+      if (!this.fetchPromise) {
+        return withSource(fallback, FALLBACK_SOURCE);
+      }
+      try {
+        await this.fetchPromise;
+        return this.getVariantSync(featureName, fallback);
+      } catch (error) {
+        MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
+        return withSource(fallback, FALLBACK_SOURCE);
+      }
     }
 
-    if (!this.flags.has(featureName)) {
-      return fallback;
+    if (!this.fetchPromise) {
+      return withSource(fallback, FALLBACK_SOURCE);
     }
-
-    const variant = this.flags.get(featureName);
-
-    // Track experiment on first access
-    if (!this.experimentTracked.has(featureName)) {
-      await this.trackExperimentStarted(featureName, variant);
+    try {
+      await this.fetchPromise;
+      return this.getVariantSync(featureName, fallback);
+    } catch (error) {
+      MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
+      return withSource(fallback, FALLBACK_SOURCE);
     }
-
-    return variant;
   }
 
-  /**
-   * Get variant value asynchronously
-   */
   async getVariantValue(featureName, fallbackValue) {
     const variant = await this.getVariant(featureName, {
       key: featureName,
@@ -374,63 +404,128 @@ export class MixpanelFlagsJS {
     return variant.value;
   }
 
-  /**
-   * Check if feature is enabled asynchronously
-   */
   async isEnabled(featureName, fallbackValue = false) {
     const value = await this.getVariantValue(featureName, fallbackValue);
-    if (typeof value === "boolean") {
+    if (typeof value === 'boolean') {
       return value;
-    } else {
-      MixpanelLogger.log(this.token, `Flag "${featureName}" value is not boolean:`, value);
-      return fallbackValue;
+    }
+    MixpanelLogger.log(
+      this.token,
+      `Flag "${featureName}" value is not boolean:`,
+      value
+    );
+    return fallbackValue;
+  }
+
+  async getAllVariants() {
+    if (!this.persistenceLoadedPromise) {
+      MixpanelLogger.error(this.token, 'Feature Flags not initialized');
+      return {};
+    }
+    await this.persistenceLoadedPromise;
+
+    const policy = this.persistence.getPolicy();
+    if (policy === VariantLookupPolicy.PERSISTENCE_UNTIL_NETWORK_SUCCESS) {
+      if (this.areFlagsReady() && !this._loadedPersistenceIsStale()) {
+        return this.getAllVariantsSync();
+      }
+      if (!this.fetchPromise) {
+        return {};
+      }
+      try {
+        await this.fetchPromise;
+        return this.getAllVariantsSync();
+      } catch (error) {
+        MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
+        return {};
+      }
+    }
+
+    if (!this.fetchPromise) {
+      return {};
+    }
+    try {
+      await this.fetchPromise;
+      return this.getAllVariantsSync();
+    } catch (error) {
+      MixpanelLogger.error(this.token, 'Error awaiting fetch:', error);
+      return {};
     }
   }
 
+  getAllVariantsSync() {
+    if (this._loadedPersistenceIsStale()) {
+      return {};
+    }
+    if (!this.areFlagsReady()) {
+      return {};
+    }
+    return this._snapshotFlags();
+  }
+
+  _snapshotFlags() {
+    const out = {};
+    this.flags.forEach((variant, key) => {
+      out[key] = variant;
+    });
+    return out;
+  }
+
   /**
-   * Update context and reload flags
-   * Aligned with mixpanel-js API signature
-   * @param {object} newContext - New context properties to add/update
-   * @param {object} options - Options object
-   * @param {boolean} options.replace - If true, replace entire context instead of merging
+   * Update context and re-fetch flags. After a context change, persisted
+   * variants captured under the old context are no longer relevant.
    */
   async updateContext(newContext, options = {}) {
     if (options.replace) {
-      // Replace entire context
       this.context = { ...newContext };
     } else {
-      // Merge with existing context (default)
       this.context = {
         ...this.context,
         ...newContext,
       };
     }
 
-    // Clear experiment tracking since context changed
+    this._loadedPersistedAtMs = null;
+    this._loadedTtlMs = null;
     this.experimentTracked.clear();
 
-    // Reload flags with new context
-    await this.loadFlags();
+    try {
+      await this.loadFlags();
+    } catch (error) {
+      MixpanelLogger.log(this.token, 'Error fetching flags during updateContext:', error);
+    }
 
-    MixpanelLogger.log(this.token, "Context updated, flags reloaded");
+    MixpanelLogger.log(this.token, 'Context updated, flags reloaded');
   }
 
-  /**
-   * Clear cached flags
-   */
-  async clearCache() {
+  /** Clear all flag state and trigger a fresh fetch under the new identity. */
+  async reset() {
+    this.flags = null;
+    this.experimentTracked.clear();
+    this._loadedPersistedAtMs = null;
+    this._loadedTtlMs = null;
     try {
-      await this.storage.removeItem(this.flagsCacheKey);
-      await this.storage.removeItem(this.flagsReadyKey);
-      this.flags = new Map();
-      this.flagsReady = false;
-      this.experimentTracked.clear();
+      await this.persistence.clear();
+      await this.loadFlags();
     } catch (error) {
-      MixpanelLogger.log(this.token, "Error clearing flag cache:", error);
+      MixpanelLogger.log(this.token, 'Error during flags reset:', error);
     }
   }
 
-  // snake_case aliases for API consistency with mixpanel-js
+  /** Discard in-memory and persisted variants. */
+  async clearCache() {
+    try {
+      await this.persistence.clear();
+      this.flags = null;
+      this.experimentTracked.clear();
+      this._loadedPersistedAtMs = null;
+      this._loadedTtlMs = null;
+    } catch (error) {
+      MixpanelLogger.log(this.token, 'Error clearing flag cache:', error);
+    }
+  }
+
+  // snake_case aliases
   are_flags_ready() {
     return this.areFlagsReady();
   }
@@ -457,6 +552,22 @@ export class MixpanelFlagsJS {
 
   is_enabled_sync(featureName, fallbackValue = false) {
     return this.isEnabledSync(featureName, fallbackValue);
+  }
+
+  get_all_variants() {
+    return this.getAllVariants();
+  }
+
+  get_all_variants_sync() {
+    return this.getAllVariantsSync();
+  }
+
+  load_flags() {
+    return this.loadFlags();
+  }
+
+  when_ready() {
+    return this.whenReady();
   }
 
   update_context(newContext, options) {

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -695,6 +695,24 @@ export class Flags {
     throw new Error("Feature flags are not initialized");
   }
 
+  /**
+   * Notify the flags system that a user event was tracked. If any pending
+   * first-time event matches, the corresponding flag's variant is switched
+   * to the pending variant and the activation is recorded with the server.
+   *
+   * <p>Native mode is a no-op — the iOS/Android SDKs handle first-time event
+   * activation internally on their own track() path. JS-fallback mode
+   * delegates to the in-memory subsystem.
+   */
+  checkFirstTimeEvents(eventName, properties) {
+    if (this.isNativeMode) {
+      return;
+    }
+    if (this.jsFlags) {
+      this.jsFlags.checkFirstTimeEvents(eventName, properties);
+    }
+  }
+
   // snake_case aliases
 
   /** Alias for {@link areFlagsReady}. */
@@ -789,5 +807,10 @@ export class Flags {
    */
   update_context(newContext, options) {
     return this.updateContext(newContext, options);
+  }
+
+  /** Alias for {@link checkFirstTimeEvents}. */
+  check_first_time_events(eventName, properties) {
+    return this.checkFirstTimeEvents(eventName, properties);
   }
 }

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -201,13 +201,10 @@ export class Flags {
    * @see getVariantValueSync to get only the value (not the full variant object)
    */
   getVariantSync(featureName, fallback) {
-    if (!this.areFlagsReady()) {
-      return fallback;
-    }
-
     if (this.isNativeMode) {
       return this.mixpanelImpl.getVariantSync(this.token, featureName, fallback);
-    } else if (this.jsFlags) {
+    }
+    if (this.jsFlags) {
       return this.jsFlags.getVariantSync(featureName, fallback);
     }
     return fallback;
@@ -255,10 +252,6 @@ export class Flags {
    * @see getVariantSync to get the full variant object including key and metadata
    */
   getVariantValueSync(featureName, fallbackValue) {
-    if (!this.areFlagsReady()) {
-      return fallbackValue;
-    }
-
     if (this.isNativeMode) {
       // Android returns a wrapped object due to React Native limitations
       const result = this.mixpanelImpl.getVariantValueSync(this.token, featureName, fallbackValue);
@@ -310,10 +303,6 @@ export class Flags {
    * @see getVariantValueSync for non-boolean flag values
    */
   isEnabledSync(featureName, fallbackValue = false) {
-    if (!this.areFlagsReady()) {
-      return fallbackValue;
-    }
-
     if (this.isNativeMode) {
       return this.mixpanelImpl.isEnabledSync(this.token, featureName, fallbackValue);
     } else if (this.jsFlags) {

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -587,26 +587,7 @@ export class Flags {
     });
   }
 
-  /**
-   * Get all currently loaded feature flag variants asynchronously.
-   *
-   * <p>Returns a Map keyed by feature name. Honors the configured `variantLookupPolicy`:
-   * `persistenceUntilNetworkSuccess` may resolve with on-disk variants before the
-   * first network fetch completes; `networkFirst` waits for the network and falls back
-   * to persisted entries on failure; `networkOnly` always waits for the network.
-   *
-   * <p>If no flags are loaded and a fetch fails, resolves with an empty Map.
-   *
-   * @param {function} [callback] Optional callback receiving the variants Map. If
-   *     provided, the method returns void. Otherwise returns a Promise.
-   * @returns {Promise<Map<string, object>>|void}
-   *
-   * @example
-   * const all = await mixpanel.flags.getAllVariants();
-   * for (const [name, variant] of all) {
-   *   console.log(name, variant.value, variant.variant_source);
-   * }
-   */
+  /** Get all loaded variants as a Map keyed by feature name. Resolves to an empty Map on failure. */
   getAllVariants(callback) {
     const run = (resolve) => {
       const handleError = (error) => {
@@ -631,21 +612,7 @@ export class Flags {
     return new Promise(run);
   }
 
-  /**
-   * Get all currently loaded feature flag variants synchronously.
-   *
-   * <p>Returns whatever is currently in memory. Returns an empty Map if flags
-   * have not been loaded, or if a persisting policy holds variants whose TTL has
-   * elapsed.
-   *
-   * @returns {Map<string, object>} Map of feature name → variant object.
-   *
-   * @example
-   * if (mixpanel.flags.areFlagsReady()) {
-   *   const all = mixpanel.flags.getAllVariantsSync();
-   *   console.log(`${all.size} flags loaded`);
-   * }
-   */
+  /** Synchronous variant of {@link getAllVariants}; returns whatever is in memory. */
   getAllVariantsSync() {
     if (this.isNativeMode) {
       return new Map(
@@ -658,29 +625,9 @@ export class Flags {
   }
 
   /**
-   * Update the context used for feature flag evaluation.
-   *
-   * <p>Context properties are used to determine which feature flag variants a user should receive
-   * based on targeting rules configured in your Mixpanel project. This allows for personalized
-   * feature experiences based on user attributes, device properties, or custom criteria.
-   *
-   * <p>By default, the new context properties are merged with existing context. Set
-   * <code>options.replace = true</code> to completely replace the context instead.
-   *
-   * <p>Native iOS/Android (Mixpanel-swift 6.4+ / mixpanel-android 8.8+) accept context
-   * updates via the new `setContext` API; JavaScript mode re-fetches flags with the
-   * updated context and writes through the persistence layer.
-   *
-   * @param {object} newContext New context properties to add or update
-   * @param {object} [options={replace: false}] If true, replaces the entire context;
-   *     otherwise merges with existing.
-   * @returns {Promise<void>}
-   *
-   * @example
-   * await mixpanel.flags.updateContext({ user_tier: 'premium', region: 'us-west' });
-   *
-   * @example
-   * await mixpanel.flags.updateContext({ device_type: 'tablet' }, { replace: true });
+   * Update the context used for feature flag evaluation. Merges by default; pass
+   * `{ replace: true }` to overwrite. Requires Mixpanel-swift 6.4+ / mixpanel-android 8.8+
+   * on native.
    */
   async updateContext(newContext, options = { replace: false }) {
     if (this.isNativeMode) {
@@ -696,13 +643,8 @@ export class Flags {
   }
 
   /**
-   * Notify the flags system that a user event was tracked. If any pending
-   * first-time event matches, the corresponding flag's variant is switched
-   * to the pending variant and the activation is recorded with the server.
-   *
-   * <p>Native mode is a no-op — the iOS/Android SDKs handle first-time event
-   * activation internally on their own track() path. JS-fallback mode
-   * delegates to the in-memory subsystem.
+   * Notify the flags system of a tracked event so any matching first-time-event
+   * activations are recorded. No-op on native (handled by the iOS/Android SDKs).
    */
   checkFirstTimeEvents(eventName, properties) {
     if (this.isNativeMode) {

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -625,16 +625,19 @@ export class Flags {
   }
 
   /**
-   * Update the context used for feature flag evaluation. Merges by default; pass
-   * `{ replace: true }` to overwrite. Requires Mixpanel-swift 6.4+ / mixpanel-android 8.8+
-   * on native.
+   * Update the context used for feature flag evaluation.
+   *
+   * In JavaScript mode, `options.replace` controls merge vs. replace semantics
+   * (merge by default). In native mode, the underlying iOS/Android SDKs always
+   * merge context and do not currently expose a replace toggle, so `options` is
+   * accepted for forward compatibility but ignored — not forwarded across the
+   * bridge. Requires Mixpanel-swift 6.4+ / mixpanel-android 8.8+ on native.
    */
   async updateContext(newContext, options = { replace: false }) {
     if (this.isNativeMode) {
       return await this.mixpanelImpl.updateFlagsContext(
         this.token,
-        newContext || {},
-        options || {}
+        newContext || {}
       );
     } else if (this.jsFlags) {
       return await this.jsFlags.updateContext(newContext, options);

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -590,20 +590,20 @@ export class Flags {
   /**
    * Get all currently loaded feature flag variants asynchronously.
    *
-   * <p>Returns a map keyed by feature name. Honors the configured `variantLookupPolicy`:
+   * <p>Returns a Map keyed by feature name. Honors the configured `variantLookupPolicy`:
    * `persistenceUntilNetworkSuccess` may resolve with on-disk variants before the
    * first network fetch completes; `networkFirst` waits for the network and falls back
    * to persisted entries on failure; `networkOnly` always waits for the network.
    *
-   * <p>If no flags are loaded and a fetch fails, resolves with an empty object.
+   * <p>If no flags are loaded and a fetch fails, resolves with an empty Map.
    *
-   * @param {function} [callback] Optional callback receiving the variants map. If
+   * @param {function} [callback] Optional callback receiving the variants Map. If
    *     provided, the method returns void. Otherwise returns a Promise.
-   * @returns {Promise<Object<string, object>>|void}
+   * @returns {Promise<Map<string, object>>|void}
    *
    * @example
    * const all = await mixpanel.flags.getAllVariants();
-   * for (const [name, variant] of Object.entries(all)) {
+   * for (const [name, variant] of all) {
    *   console.log(name, variant.value, variant.variant_source);
    * }
    */
@@ -611,14 +611,17 @@ export class Flags {
     const run = (resolve) => {
       const handleError = (error) => {
         MixpanelLogger.error(this.token, "Failed to get all variants:", error);
-        resolve({});
+        resolve(new Map());
       };
       if (this.isNativeMode) {
-        this.mixpanelImpl.getAllVariants(this.token).then(resolve).catch(handleError);
+        this.mixpanelImpl
+          .getAllVariants(this.token)
+          .then((obj) => resolve(new Map(Object.entries(obj || {}))))
+          .catch(handleError);
       } else if (this.jsFlags) {
         this.jsFlags.getAllVariants().then(resolve).catch(handleError);
       } else {
-        resolve({});
+        resolve(new Map());
       }
     };
     if (typeof callback === 'function') {
@@ -631,25 +634,27 @@ export class Flags {
   /**
    * Get all currently loaded feature flag variants synchronously.
    *
-   * <p>Returns whatever is currently in memory. Returns an empty object if flags
+   * <p>Returns whatever is currently in memory. Returns an empty Map if flags
    * have not been loaded, or if a persisting policy holds variants whose TTL has
    * elapsed.
    *
-   * @returns {Object<string, object>} Map of feature name → variant object.
+   * @returns {Map<string, object>} Map of feature name → variant object.
    *
    * @example
    * if (mixpanel.flags.areFlagsReady()) {
    *   const all = mixpanel.flags.getAllVariantsSync();
-   *   console.log(`${Object.keys(all).length} flags loaded`);
+   *   console.log(`${all.size} flags loaded`);
    * }
    */
   getAllVariantsSync() {
     if (this.isNativeMode) {
-      return this.mixpanelImpl.getAllVariantsSync(this.token) || {};
+      return new Map(
+        Object.entries(this.mixpanelImpl.getAllVariantsSync(this.token) || {})
+      );
     } else if (this.jsFlags) {
       return this.jsFlags.getAllVariantsSync();
     }
-    return {};
+    return new Map();
   }
 
   /**

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -68,17 +68,19 @@ import { MixpanelLogger } from './mixpanel-logger';
  * @see Mixpanel#flags
  */
 export class Flags {
-  constructor(token, mixpanelImpl, storage) {
+  constructor(token, mixpanelImpl) {
     this.token = token;
     this.mixpanelImpl = mixpanelImpl;
-    this.storage = storage;
     this.isNativeMode = typeof mixpanelImpl.loadFlags === 'function';
 
-    if (!this.isNativeMode && storage) {
+    if (!this.isNativeMode) {
+      // Reuse the adapter MixpanelPersistent already built so flags inherit
+      // the same "user-supplied storage → auto-required AsyncStorage →
+      // InMemoryStorage fallback" resolution the rest of persistence uses.
       this.jsFlags = new MixpanelFlagsJS(
         token,
         mixpanelImpl,
-        storage,
+        mixpanelImpl.mixpanelPersistent.storageAdapter,
         mixpanelImpl.getFeatureFlagsOptions()
       );
       this.jsFlags.init();
@@ -699,22 +701,6 @@ export class Flags {
     }
   }
 
-  /**
-   * Resolves when the next/in-flight flag fetch settles. In native mode this
-   * resolves immediately (the native SDK doesn't expose an equivalent
-   * primitive). In JS-fallback mode, returns the in-flight fetch promise if
-   * one is running.
-   */
-  whenReady() {
-    if (this.isNativeMode) {
-      return Promise.resolve();
-    }
-    if (this.jsFlags) {
-      return this.jsFlags.whenReady();
-    }
-    return Promise.resolve();
-  }
-
   /** Alias for {@link getAllVariants}. */
   get_all_variants(callback) {
     return this.getAllVariants(callback);
@@ -728,11 +714,6 @@ export class Flags {
   /** Alias for {@link loadFlags}. */
   load_flags() {
     return this.loadFlags();
-  }
-
-  /** Alias for {@link whenReady}. */
-  when_ready() {
-    return this.whenReady();
   }
 
   /**

--- a/javascript/mixpanel-flags.js
+++ b/javascript/mixpanel-flags.js
@@ -74,11 +74,14 @@ export class Flags {
     this.storage = storage;
     this.isNativeMode = typeof mixpanelImpl.loadFlags === 'function';
 
-    // For JavaScript mode, create the JS implementation
     if (!this.isNativeMode && storage) {
-      // Get the initial context from mixpanelImpl (always MixpanelMain in JS mode)
-      const initialContext = mixpanelImpl.getFeatureFlagsContext();
-      this.jsFlags = new MixpanelFlagsJS(token, mixpanelImpl, storage, initialContext);
+      this.jsFlags = new MixpanelFlagsJS(
+        token,
+        mixpanelImpl,
+        storage,
+        mixpanelImpl.getFeatureFlagsOptions()
+      );
+      this.jsFlags.init();
     }
   }
 
@@ -585,57 +588,101 @@ export class Flags {
   }
 
   /**
+   * Get all currently loaded feature flag variants asynchronously.
+   *
+   * <p>Returns a map keyed by feature name. Honors the configured `variantLookupPolicy`:
+   * `persistenceUntilNetworkSuccess` may resolve with on-disk variants before the
+   * first network fetch completes; `networkFirst` waits for the network and falls back
+   * to persisted entries on failure; `networkOnly` always waits for the network.
+   *
+   * <p>If no flags are loaded and a fetch fails, resolves with an empty object.
+   *
+   * @param {function} [callback] Optional callback receiving the variants map. If
+   *     provided, the method returns void. Otherwise returns a Promise.
+   * @returns {Promise<Object<string, object>>|void}
+   *
+   * @example
+   * const all = await mixpanel.flags.getAllVariants();
+   * for (const [name, variant] of Object.entries(all)) {
+   *   console.log(name, variant.value, variant.variant_source);
+   * }
+   */
+  getAllVariants(callback) {
+    const run = (resolve) => {
+      const handleError = (error) => {
+        MixpanelLogger.error(this.token, "Failed to get all variants:", error);
+        resolve({});
+      };
+      if (this.isNativeMode) {
+        this.mixpanelImpl.getAllVariants(this.token).then(resolve).catch(handleError);
+      } else if (this.jsFlags) {
+        this.jsFlags.getAllVariants().then(resolve).catch(handleError);
+      } else {
+        resolve({});
+      }
+    };
+    if (typeof callback === 'function') {
+      run((variants) => callback(variants));
+      return;
+    }
+    return new Promise(run);
+  }
+
+  /**
+   * Get all currently loaded feature flag variants synchronously.
+   *
+   * <p>Returns whatever is currently in memory. Returns an empty object if flags
+   * have not been loaded, or if a persisting policy holds variants whose TTL has
+   * elapsed.
+   *
+   * @returns {Object<string, object>} Map of feature name → variant object.
+   *
+   * @example
+   * if (mixpanel.flags.areFlagsReady()) {
+   *   const all = mixpanel.flags.getAllVariantsSync();
+   *   console.log(`${Object.keys(all).length} flags loaded`);
+   * }
+   */
+  getAllVariantsSync() {
+    if (this.isNativeMode) {
+      return this.mixpanelImpl.getAllVariantsSync(this.token) || {};
+    } else if (this.jsFlags) {
+      return this.jsFlags.getAllVariantsSync();
+    }
+    return {};
+  }
+
+  /**
    * Update the context used for feature flag evaluation.
    *
    * <p>Context properties are used to determine which feature flag variants a user should receive
    * based on targeting rules configured in your Mixpanel project. This allows for personalized
    * feature experiences based on user attributes, device properties, or custom criteria.
    *
-   * <p><b>IMPORTANT LIMITATION:</b> This method is <b>only available in JavaScript mode</b>
-   * (Expo/React Native Web). In native mode (iOS/Android), context must be set during initialization
-   * via {@link Mixpanel#init} and cannot be updated at runtime.
-   *
    * <p>By default, the new context properties are merged with existing context. Set
    * <code>options.replace = true</code> to completely replace the context instead.
    *
-   * @param {object} newContext New context properties to add or update. Can include any
-   *     JSON-serializable properties that are used in your feature flag targeting rules.
-   *     Common examples include user tier, region, platform version, etc.
-   * @param {object} [options={replace: false}] Configuration options for the update
-   * @param {boolean} [options.replace=false] If true, replaces the entire context instead of merging.
-   *     If false (default), merges new properties with existing context.
-   * @returns {Promise<void>} A promise that resolves when the context has been updated and
-   *     flags have been re-evaluated with the new context
-   * @throws {Error} if called in native mode (iOS/Android)
+   * <p>Native iOS/Android (Mixpanel-swift 6.4+ / mixpanel-android 8.8+) accept context
+   * updates via the new `setContext` API; JavaScript mode re-fetches flags with the
+   * updated context and writes through the persistence layer.
+   *
+   * @param {object} newContext New context properties to add or update
+   * @param {object} [options={replace: false}] If true, replaces the entire context;
+   *     otherwise merges with existing.
+   * @returns {Promise<void>}
    *
    * @example
-   * // Merge new properties into existing context (JavaScript mode only)
-   * await mixpanel.flags.updateContext({
-   *   user_tier: 'premium',
-   *   region: 'us-west'
-   * });
+   * await mixpanel.flags.updateContext({ user_tier: 'premium', region: 'us-west' });
    *
    * @example
-   * // Replace entire context (JavaScript mode only)
-   * await mixpanel.flags.updateContext({
-   *   device_type: 'tablet',
-   *   os_version: '14.0'
-   * }, { replace: true });
-   *
-   * @example
-   * // This will throw an error in native mode
-   * try {
-   *   await mixpanel.flags.updateContext({ tier: 'premium' });
-   * } catch (error) {
-   *   console.error('Context updates not supported in native mode');
-   * }
+   * await mixpanel.flags.updateContext({ device_type: 'tablet' }, { replace: true });
    */
   async updateContext(newContext, options = { replace: false }) {
     if (this.isNativeMode) {
-      throw new Error(
-        "updateContext() is not supported in native mode. " +
-        "Context must be set during initialization via FeatureFlagsOptions. " +
-        "This feature is only available in JavaScript mode (Expo/React Native Web)."
+      return await this.mixpanelImpl.updateFlagsContext(
+        this.token,
+        newContext || {},
+        options || {}
       );
     } else if (this.jsFlags) {
       return await this.jsFlags.updateContext(newContext, options);
@@ -643,67 +690,96 @@ export class Flags {
     throw new Error("Feature flags are not initialized");
   }
 
-  // snake_case aliases for API consistency with mixpanel-js
+  // snake_case aliases
 
-  /**
-   * Alias for {@link areFlagsReady}. Provided for API consistency with mixpanel-js.
-   * @see areFlagsReady
-   */
+  /** Alias for {@link areFlagsReady}. */
   are_flags_ready() {
     return this.areFlagsReady();
   }
 
-  /**
-   * Alias for {@link getVariant}. Provided for API consistency with mixpanel-js.
-   * @see getVariant
-   */
+  /** Alias for {@link getVariant}. */
   get_variant(featureName, fallback, callback) {
     return this.getVariant(featureName, fallback, callback);
   }
 
-  /**
-   * Alias for {@link getVariantSync}. Provided for API consistency with mixpanel-js.
-   * @see getVariantSync
-   */
+  /** Alias for {@link getVariantSync}. */
   get_variant_sync(featureName, fallback) {
     return this.getVariantSync(featureName, fallback);
   }
 
-  /**
-   * Alias for {@link getVariantValue}. Provided for API consistency with mixpanel-js.
-   * @see getVariantValue
-   */
+  /** Alias for {@link getVariantValue}. */
   get_variant_value(featureName, fallbackValue, callback) {
     return this.getVariantValue(featureName, fallbackValue, callback);
   }
 
-  /**
-   * Alias for {@link getVariantValueSync}. Provided for API consistency with mixpanel-js.
-   * @see getVariantValueSync
-   */
+  /** Alias for {@link getVariantValueSync}. */
   get_variant_value_sync(featureName, fallbackValue) {
     return this.getVariantValueSync(featureName, fallbackValue);
   }
 
-  /**
-   * Alias for {@link isEnabled}. Provided for API consistency with mixpanel-js.
-   * @see isEnabled
-   */
+  /** Alias for {@link isEnabled}. */
   is_enabled(featureName, fallbackValue, callback) {
     return this.isEnabled(featureName, fallbackValue, callback);
   }
 
-  /**
-   * Alias for {@link isEnabledSync}. Provided for API consistency with mixpanel-js.
-   * @see isEnabledSync
-   */
+  /** Alias for {@link isEnabledSync}. */
   is_enabled_sync(featureName, fallbackValue) {
     return this.isEnabledSync(featureName, fallbackValue);
   }
 
   /**
-   * Alias for {@link updateContext}. Provided for API consistency with mixpanel-js.
-   * JavaScript mode only.
+   * Clear feature flag state. Native mode is a no-op — the native SDKs handle
+   * flag re-fetch on their own reset. JS-fallback mode clears the in-memory
+   * map, removes the persisted blob, and triggers a fresh fetch under the
+   * new identity.
+   */
+  async reset() {
+    if (this.isNativeMode) {
+      return;
+    }
+    if (this.jsFlags) {
+      return this.jsFlags.reset();
+    }
+  }
+
+  /**
+   * Resolves when the next/in-flight flag fetch settles. In native mode this
+   * resolves immediately (the native SDK doesn't expose an equivalent
+   * primitive). In JS-fallback mode, returns the in-flight fetch promise if
+   * one is running.
+   */
+  whenReady() {
+    if (this.isNativeMode) {
+      return Promise.resolve();
+    }
+    if (this.jsFlags) {
+      return this.jsFlags.whenReady();
+    }
+    return Promise.resolve();
+  }
+
+  /** Alias for {@link getAllVariants}. */
+  get_all_variants(callback) {
+    return this.getAllVariants(callback);
+  }
+
+  /** Alias for {@link getAllVariantsSync}. */
+  get_all_variants_sync() {
+    return this.getAllVariantsSync();
+  }
+
+  /** Alias for {@link loadFlags}. */
+  load_flags() {
+    return this.loadFlags();
+  }
+
+  /** Alias for {@link whenReady}. */
+  when_ready() {
+    return this.whenReady();
+  }
+
+  /**
+   * Alias for {@link updateContext}.
    * @see updateContext
    */
   update_context(newContext, options) {

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -144,6 +144,19 @@ export default class MixpanelMain {
       this.mixpanelPersistent.updateTimeEvents(token, timeEvents);
       await this.mixpanelPersistent.persistTimeEvents(token);
     }
+
+    // Notify the JS-fallback flags subsystem so it can activate any
+    // matching first-time event and switch the corresponding variant.
+    // Self-registered as `_flagsJS` by MixpanelFlagsJS.init(); absent in
+    // native mode (the platform SDK handles this internally).
+    if (this._flagsJS) {
+      try {
+        this._flagsJS.checkFirstTimeEvents(eventName, properties);
+      } catch (e) {
+        MixpanelLogger.log(token, "checkFirstTimeEvents error:", e);
+      }
+    }
+
     await this.core.addToMixpanelQueue(token, MixpanelType.EVENTS, eventData);
   }
 

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -90,6 +90,16 @@ export default class MixpanelMain {
     return this.featureFlagsContext || {};
   }
 
+  /**
+   * Get the full feature flags options object that was provided during
+   * initialization. Used by the JS-fallback Flags impl to read the
+   * variantLookupPolicy and any other persistence-related configuration.
+   * @returns {object}
+   */
+  getFeatureFlagsOptions() {
+    return this.featureFlagsOptions || {};
+  }
+
   async track(token, eventName, properties) {
     if (this.mixpanelPersistent.getOptedOut(token)) {
       MixpanelLogger.log(

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -219,12 +219,24 @@ export default class MixpanelMain {
     const deviceId = this.mixpanelPersistent.getDeviceId(token);
     await this.mixpanelPersistent.persistIdentity(token);
     await this.core.identifyUserQueue(token);
+
     await this.track(token, "$identify", {
       distinctId: newDistinctId,
       $user_id: newDistinctId,
       $anon_distinct_id: oldDistinctId,
       $device_id: deviceId,
     });
+
+    if (this._flagsJS) {
+      this._flagsJS._invalidateInFlightFetch();
+      this._flagsJS.loadFlags().catch(() => {
+        MixpanelLogger.log(
+          token,
+          `Failed to load flags for distinct Id ${newDistinctId}.`
+        );
+      });
+    }
+
   }
 
   async alias(token, alias, distinctId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "mixpanel-react-native",
-  "version": "3.2.0-beta.2",
+  "version": "3.2.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mixpanel-react-native",
-      "version": "3.2.0-beta.2",
+      "version": "3.2.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.24.0",
+        "base-64": "^1.0.0",
         "react-native-get-random-values": "^1.9.0",
         "uuid": "3.3.2"
       },
@@ -68,7 +69,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1202,7 +1202,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3064,7 +3063,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -3187,7 +3185,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.10.1.tgz",
       "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-visitor-keys": "^1.0.0",
         "@typescript-eslint/experimental-utils": "3.10.1",
@@ -3328,7 +3325,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4077,6 +4073,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -4197,7 +4199,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -5142,7 +5143,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -5435,7 +5435,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -12625,7 +12624,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -12840,7 +12838,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.63.5.tgz",
       "integrity": "sha512-unjHZOcHek2xxPkBbyqGO//2Z/AriKTwtDzGTT/ujGMRE3odDJk8wKtZregurQ9cpTUtu1Bj5R5bJv3gQIG5zw==",
       "deprecated": "Issues and pull requests filed against this version are not supported. See the React Native release support policy to learn more: https://github.com/reactwg/react-native-releases#releases-support-policy",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@react-native-community/cli": "^4.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.24.0",
         "base-64": "^1.0.0",
+        "json-logic-js": "^2.0.5",
         "react-native-get-random-values": "^1.9.0",
         "uuid": "3.3.2"
       },
@@ -9652,6 +9653,12 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-logic-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.24.0",
+    "base-64": "^1.0.0",
     "react-native-get-random-values": "^1.9.0",
     "uuid": "3.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.24.0",
     "base-64": "^1.0.0",
+    "json-logic-js": "^2.0.5",
     "react-native-get-random-values": "^1.9.0",
     "uuid": "3.3.2"
   }


### PR DESCRIPTION
Introduces several changes to attain parity with other client feature flags SDKs

- Upgrades Android & iOS versions for the native bridges.
- Implements reset reloading flag for react native web ( android & ios) will just bridge to reset on that end with the package update
- React Native Web parity with Javascript browser SDK, as it had multiple bugs and behavior that was not in line. E.x Runtime event support
- Qa'd in web non-native, ios native, android native mode