### PR TITLE
feat(analytics): add trackScreenView and trackScreenLeave public APIs

### DIFF
--- a/Samples/MixpanelStarter/metro.config.js
+++ b/Samples/MixpanelStarter/metro.config.js
@@ -21,8 +21,7 @@ const config = {
     blockList: [
       // Exclude node_modules from parent package to prevent conflicts,
       // but allow SDK-only dependencies (json-logic-js, base-64) through
-      new RegExp(`${parentPackage.replace(/[/\\]/g, '[/\\\\]')}/node_modules/(?!json-logic-js|base-64).*`),
-    ],
+      new RegExp(`${parentPackage.replace(/[/\\]/g, '[/\\\\]')}/node_modules/(?!((json-logic-js|base-64)(/|$))).*`),
     extraNodeModules: {
       // Ensure react-native and other deps resolve from sample app's node_modules
       'react-native': path.resolve(__dirname, 'node_modules/react-native'),

--- a/Samples/MixpanelStarter/metro.config.js
+++ b/Samples/MixpanelStarter/metro.config.js
@@ -19,8 +19,9 @@ const config = {
   resolver: {
     // Prevent multiple copies of React Native
     blockList: [
-      // Exclude node_modules from parent package to prevent conflicts
-      new RegExp(`${parentPackage.replace(/[/\\]/g, '[/\\\\]')}/node_modules/.*`),
+      // Exclude node_modules from parent package to prevent conflicts,
+      // but allow SDK-only dependencies (json-logic-js, base-64) through
+      new RegExp(`${parentPackage.replace(/[/\\]/g, '[/\\\\]')}/node_modules/(?!json-logic-js|base-64).*`),
     ],
     extraNodeModules: {
       // Ensure react-native and other deps resolve from sample app's node_modules
@@ -29,6 +30,9 @@ const config = {
       '@react-native-async-storage/async-storage': path.resolve(__dirname, 'node_modules/@react-native-async-storage/async-storage'),
       'react-native-get-random-values': path.resolve(__dirname, 'node_modules/react-native-get-random-values'),
       'uuid': path.resolve(__dirname, 'node_modules/uuid'),
+      // SDK dependencies that live in the parent package's node_modules
+      'json-logic-js': path.resolve(parentPackage, 'node_modules/json-logic-js'),
+      'base-64': path.resolve(parentPackage, 'node_modules/base-64'),
       // Resolve mixpanel-react-native to parent package
       'mixpanel-react-native': parentPackage,
     },

--- a/Samples/MixpanelStarter/src/App.tsx
+++ b/Samples/MixpanelStarter/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {
   NavigationContainer,
   useNavigationContainerRef,
@@ -23,6 +23,24 @@ function AppNavigator(): React.JSX.Element {
   const {mixpanel, isInitialized} = useMixpanel();
   const navigationRef = useNavigationContainerRef();
   const previousRouteNameRef = useRef<string | undefined>();
+  const isNavigationReadyRef = useRef(false);
+  const initialScreenTrackedRef = useRef(false);
+
+  // Track initial screen view once both navigation and Mixpanel are ready
+  useEffect(() => {
+    if (
+      isInitialized &&
+      mixpanel &&
+      isNavigationReadyRef.current &&
+      !initialScreenTrackedRef.current
+    ) {
+      const currentRoute = navigationRef.getCurrentRoute()?.name;
+      if (currentRoute) {
+        mixpanel.autocapture.trackScreenView(currentRoute);
+        initialScreenTrackedRef.current = true;
+      }
+    }
+  }, [isInitialized, mixpanel, navigationRef]);
 
   return (
     <NavigationContainer
@@ -30,8 +48,10 @@ function AppNavigator(): React.JSX.Element {
       onReady={() => {
         const initialRouteName = navigationRef.getCurrentRoute()?.name;
         previousRouteNameRef.current = initialRouteName;
+        isNavigationReadyRef.current = true;
         if (isInitialized && mixpanel && initialRouteName) {
           mixpanel.autocapture.trackScreenView(initialRouteName);
+          initialScreenTrackedRef.current = true;
         }
       }}
       onStateChange={() => {

--- a/Samples/MixpanelStarter/src/App.tsx
+++ b/Samples/MixpanelStarter/src/App.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
-import {NavigationContainer} from '@react-navigation/native';
+import React, {useRef} from 'react';
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {Text} from 'react-native';
-import {MixpanelProvider} from './contexts/MixpanelContext';
+import {MixpanelProvider, useMixpanel} from './contexts/MixpanelContext';
 import {ErrorBoundary} from './components/ErrorBoundary';
 import {OnboardingScreen} from './screens/OnboardingScreen';
 import {HomeScreen} from './screens/HomeScreen';
@@ -16,12 +19,38 @@ const Tab = createBottomTabNavigator();
 const DEMO_TOKEN = 'YOUR_TOKEN_HERE';
 const token = MIXPANEL_TOKEN || DEMO_TOKEN;
 
-function App(): React.JSX.Element {
+function AppNavigator(): React.JSX.Element {
+  const {mixpanel, isInitialized} = useMixpanel();
+  const navigationRef = useNavigationContainerRef();
+  const previousRouteNameRef = useRef<string | undefined>();
+
   return (
-    <ErrorBoundary>
-      <MixpanelProvider token={token} trackAutomaticEvents={true} useNative={true} serverURL="https://api-eu.mixpanel.com">
-        <NavigationContainer>
-          <Tab.Navigator
+    <NavigationContainer
+      ref={navigationRef}
+      onReady={() => {
+        const initialRouteName = navigationRef.getCurrentRoute()?.name;
+        previousRouteNameRef.current = initialRouteName;
+        if (isInitialized && mixpanel && initialRouteName) {
+          mixpanel.autocapture.trackScreenView(initialRouteName);
+        }
+      }}
+      onStateChange={() => {
+        const currentRouteName = navigationRef.getCurrentRoute()?.name;
+        const previousRouteName = previousRouteNameRef.current;
+
+        if (currentRouteName !== previousRouteName) {
+          if (isInitialized && mixpanel) {
+            if (previousRouteName) {
+              mixpanel.autocapture.trackScreenLeave(previousRouteName);
+            }
+            if (currentRouteName) {
+              mixpanel.autocapture.trackScreenView(currentRouteName);
+            }
+          }
+          previousRouteNameRef.current = currentRouteName;
+        }
+      }}>
+      <Tab.Navigator
             screenOptions={{
               tabBarActiveTintColor: '#007AFF',
               tabBarInactiveTintColor: '#8E8E93',
@@ -74,7 +103,15 @@ function App(): React.JSX.Element {
               }}
             />
           </Tab.Navigator>
-        </NavigationContainer>
+    </NavigationContainer>
+  );
+}
+
+function App(): React.JSX.Element {
+  return (
+    <ErrorBoundary>
+      <MixpanelProvider token={token} trackAutomaticEvents={true} useNative={true} serverURL="https://api-eu.mixpanel.com">
+        <AppNavigator />
       </MixpanelProvider>
     </ErrorBoundary>
   );

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -476,3 +476,84 @@ test(`it calls MixpanelReactNative group union property`, async () => {
     NativeModules.MixpanelReactNative.groupRemovePropertyValue
   ).toBeCalledWith("token", "company_id", 12345, "prop_key", "334");
 });
+
+test(`autocapture getter returns an Autocapture instance and is lazily initialized`, async () => {
+  const mixpanel = new Mixpanel("token", true);
+  mixpanel.init();
+  const autocapture1 = mixpanel.autocapture;
+  const autocapture2 = mixpanel.autocapture;
+  expect(autocapture1).toBeDefined();
+  expect(autocapture1).toBe(autocapture2);
+});
+
+test(`autocapture.trackScreenView calls MixpanelReactNative trackScreenView with token and merged metadata`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  mixpanel.autocapture.trackScreenView("HomeScreen", { custom_prop: "value" });
+  expect(NativeModules.MixpanelReactNative.trackScreenView).toBeCalledWith(
+    "token",
+    "HomeScreen",
+    {
+      $lib_version: expect.any(String),
+      mp_lib: "react-native",
+      custom_prop: "value",
+    }
+  );
+});
+
+test(`autocapture.trackScreenView calls MixpanelReactNative trackScreenView with only metadata when no extra properties given`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  mixpanel.autocapture.trackScreenView("HomeScreen");
+  expect(NativeModules.MixpanelReactNative.trackScreenView).toBeCalledWith(
+    "token",
+    "HomeScreen",
+    {
+      $lib_version: expect.any(String),
+      mp_lib: "react-native",
+    }
+  );
+});
+
+test(`autocapture.trackScreenView does not call native module when screenName is invalid`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  NativeModules.MixpanelReactNative.trackScreenView.mockClear();
+  mixpanel.autocapture.trackScreenView("");
+  expect(NativeModules.MixpanelReactNative.trackScreenView).not.toBeCalled();
+  mixpanel.autocapture.trackScreenView(null);
+  expect(NativeModules.MixpanelReactNative.trackScreenView).not.toBeCalled();
+});
+
+test(`autocapture.trackScreenLeave calls MixpanelReactNative trackScreenLeave with token and merged metadata`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  mixpanel.autocapture.trackScreenLeave("HomeScreen", { custom_prop: "value" });
+  expect(NativeModules.MixpanelReactNative.trackScreenLeave).toBeCalledWith(
+    "token",
+    "HomeScreen",
+    {
+      $lib_version: expect.any(String),
+      mp_lib: "react-native",
+      custom_prop: "value",
+    }
+  );
+});
+
+test(`autocapture.trackScreenLeave calls MixpanelReactNative trackScreenLeave with only metadata when no extra properties given`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  mixpanel.autocapture.trackScreenLeave("HomeScreen");
+  expect(NativeModules.MixpanelReactNative.trackScreenLeave).toBeCalledWith(
+    "token",
+    "HomeScreen",
+    {
+      $lib_version: expect.any(String),
+      mp_lib: "react-native",
+    }
+  );
+});
+
+test(`autocapture.trackScreenLeave does not call native module when screenName is invalid`, async () => {
+  const mixpanel = await Mixpanel.init("token", true);
+  NativeModules.MixpanelReactNative.trackScreenLeave.mockClear();
+  mixpanel.autocapture.trackScreenLeave("");
+  expect(NativeModules.MixpanelReactNative.trackScreenLeave).not.toBeCalled();
+  mixpanel.autocapture.trackScreenLeave(null);
+  expect(NativeModules.MixpanelReactNative.trackScreenLeave).not.toBeCalled();
+});

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -118,6 +118,8 @@ jest.doMock("react-native", () => {
           updateContext: jest.fn().mockResolvedValue(undefined),  // legacy alias, retained
           updateFlagsContext: jest.fn().mockResolvedValue(true),
           checkFirstTimeEvents: jest.fn(),
+          trackScreenView: jest.fn(),
+          trackScreenLeave: jest.fn(),
         },
       },
     },

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -896,4 +896,80 @@ describe("MixpanelMain", () => {
       })
     );
   });
+
+  describe("trackScreenView", () => {
+    it("should track $mp_page_view with current_page_title and $mp_autocapture", async () => {
+      const screenName = "HomeScreen";
+      const properties = { prop1: "value1" };
+
+      await mixpanelMain.trackScreenView(token, screenName, properties);
+
+      expect(mixpanelMain.core.addToMixpanelQueue).toHaveBeenCalledWith(
+        token,
+        MixpanelType.EVENTS,
+        expect.objectContaining({
+          event: "$mp_page_view",
+          properties: expect.objectContaining({
+            token: token,
+            current_page_title: screenName,
+            $mp_autocapture: true,
+            prop1: "value1",
+          }),
+        })
+      );
+    });
+
+    it("should return early when screenName is not a string", async () => {
+      await mixpanelMain.trackScreenView(token, 123, {});
+      expect(mixpanelMain.core.addToMixpanelQueue).not.toHaveBeenCalled();
+    });
+
+    it("should return early when screenName is an empty string", async () => {
+      await mixpanelMain.trackScreenView(token, "", {});
+      expect(mixpanelMain.core.addToMixpanelQueue).not.toHaveBeenCalled();
+    });
+
+    it("should return early when screenName is a whitespace-only string", async () => {
+      await mixpanelMain.trackScreenView(token, "   ", {});
+      expect(mixpanelMain.core.addToMixpanelQueue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("trackScreenLeave", () => {
+    it("should track $mp_page_leave with current_page_title and $mp_autocapture", async () => {
+      const screenName = "HomeScreen";
+      const properties = { prop1: "value1" };
+
+      await mixpanelMain.trackScreenLeave(token, screenName, properties);
+
+      expect(mixpanelMain.core.addToMixpanelQueue).toHaveBeenCalledWith(
+        token,
+        MixpanelType.EVENTS,
+        expect.objectContaining({
+          event: "$mp_page_leave",
+          properties: expect.objectContaining({
+            token: token,
+            current_page_title: screenName,
+            $mp_autocapture: true,
+            prop1: "value1",
+          }),
+        })
+      );
+    });
+
+    it("should return early when screenName is not a string", async () => {
+      await mixpanelMain.trackScreenLeave(token, null, {});
+      expect(mixpanelMain.core.addToMixpanelQueue).not.toHaveBeenCalled();
+    });
+
+    it("should return early when screenName is an empty string", async () => {
+      await mixpanelMain.trackScreenLeave(token, "", {});
+      expect(mixpanelMain.core.addToMixpanelQueue).not.toHaveBeenCalled();
+    });
+
+    it("should return early when screenName is a whitespace-only string", async () => {
+      await mixpanelMain.trackScreenLeave(token, "   ", {});
+      expect(mixpanelMain.core.addToMixpanelQueue).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -269,7 +269,9 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         synchronized (instance) {
             JSONObject eventProperties = ReactNativeHelper.reactToJSON(properties);
             AutomaticProperties.appendLibraryProperties(eventProperties);
-            instance.getAutocapture().trackScreenView(screenName, eventProperties);
+            if (instance.getAutocapture() != null) {
+                instance.getAutocapture().trackScreenView(screenName, eventProperties);
+            }
             promise.resolve(null);
         }
     }
@@ -284,7 +286,9 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
         synchronized (instance) {
             JSONObject eventProperties = ReactNativeHelper.reactToJSON(properties);
             AutomaticProperties.appendLibraryProperties(eventProperties);
-            instance.getAutocapture().trackScreenLeave(screenName, eventProperties);
+            if (instance.getAutocapture() != null) {
+                instance.getAutocapture().trackScreenLeave(screenName, eventProperties);
+            }
             promise.resolve(null);
         }
     }

--- a/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
+++ b/android/src/main/java/com/mixpanel/reactnative/MixpanelReactNativeModule.java
@@ -260,6 +260,36 @@ public class MixpanelReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void trackScreenView(final String token, final String screenName, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
+        if (instance == null) {
+            promise.reject("Instance Error", "Failed to get Mixpanel instance");
+            return;
+        }
+        synchronized (instance) {
+            JSONObject eventProperties = ReactNativeHelper.reactToJSON(properties);
+            AutomaticProperties.appendLibraryProperties(eventProperties);
+            instance.getAutocapture().trackScreenView(screenName, eventProperties);
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
+    public void trackScreenLeave(final String token, final String screenName, ReadableMap properties, Promise promise) throws JSONException {
+        MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
+        if (instance == null) {
+            promise.reject("Instance Error", "Failed to get Mixpanel instance");
+            return;
+        }
+        synchronized (instance) {
+            JSONObject eventProperties = ReactNativeHelper.reactToJSON(properties);
+            AutomaticProperties.appendLibraryProperties(eventProperties);
+            instance.getAutocapture().trackScreenLeave(screenName, eventProperties);
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
     public void registerSuperProperties(final String token, ReadableMap properties, Promise promise) throws JSONException {
         MixpanelAPI instance = MixpanelAPI.getInstance(this.mReactContext, token, true);
         if (instance == null) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,8 +102,14 @@ export interface Flags {
   check_first_time_events(eventName: string, properties?: MixpanelProperties): void;
 }
 
+export class Autocapture {
+  trackScreenView(screenName: string, properties?: MixpanelProperties): void;
+  trackScreenLeave(screenName: string, properties?: MixpanelProperties): void;
+}
+
 export class Mixpanel {
   readonly flags: Flags;
+  readonly autocapture: Autocapture;
 
   constructor(token: string, trackAutoMaticEvents: boolean);
   constructor(token: string, trackAutoMaticEvents: boolean, useNative: true);

--- a/index.js
+++ b/index.js
@@ -731,6 +731,10 @@ export class Autocapture {
    */
   trackScreenView(screenName, properties) {
     if (!StringHelper.isValid(screenName)) {
+      MixpanelLogger.warn(
+        this.token,
+        `trackScreenView failed: screenName cannot be blank`
+      );
       return;
     }
     if (!ObjectHelper.isValidOrUndefined(properties)) {
@@ -751,6 +755,10 @@ export class Autocapture {
    */
   trackScreenLeave(screenName, properties) {
     if (!StringHelper.isValid(screenName)) {
+      MixpanelLogger.warn(
+        this.token,
+        `trackScreenLeave failed: screenName cannot be blank`
+      );
       return;
     }
     if (!ObjectHelper.isValidOrUndefined(properties)) {

--- a/index.js
+++ b/index.js
@@ -105,6 +105,20 @@ export class Mixpanel {
   }
 
   /**
+   * Returns the Autocapture instance for screen view tracking operations.
+   *
+   * @return {Autocapture} an instance of Autocapture that provides access to screen view tracking
+   *
+   * @see Autocapture
+   */
+  get autocapture() {
+    if (!this._autocapture) {
+      this._autocapture = new Autocapture(this.token, this.mixpanelImpl);
+    }
+    return this._autocapture;
+  }
+
+  /**
    * Initializes Mixpanel with optional configuration for tracking, super properties, and feature flags.
    *
    * <p>This method must be called before using any other Mixpanel functionality. It sets up
@@ -690,20 +704,6 @@ export class Mixpanel {
    * need to call flush() to let the Mixpanel library know it should
    * send all remaining messages to the server.
    */
-  /**
-   * Returns the Autocapture instance for screen view tracking operations.
-   *
-   * @return {Autocapture} an instance of Autocapture that provides access to screen view tracking
-   *
-   * @see Autocapture
-   */
-  get autocapture() {
-    if (!this._autocapture) {
-      this._autocapture = new Autocapture(this.token, this.mixpanelImpl);
-    }
-    return this._autocapture;
-  }
-
   flush() {
     this.mixpanelImpl.flush(this.token);
   }

--- a/index.js
+++ b/index.js
@@ -739,8 +739,6 @@ export class Autocapture {
     const mergedProperties = {
       ...Helper.getMetaData(),
       ...properties,
-      current_page_title: screenName,
-      $mp_autocapture: true,
     };
     this.mixpanelImpl.trackScreenView(this.token, screenName, mergedProperties);
   }
@@ -761,8 +759,6 @@ export class Autocapture {
     const mergedProperties = {
       ...Helper.getMetaData(),
       ...properties,
-      current_page_title: screenName,
-      $mp_autocapture: true,
     };
     this.mixpanelImpl.trackScreenLeave(this.token, screenName, mergedProperties);
   }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ export class Mixpanel {
     this.token = token;
     this.trackAutomaticEvents = trackAutomaticEvents;
     this._flags = null; // Lazy-loaded flags instance
+    this._autocapture = null; // Lazy-loaded autocapture instance
     this.storage = storage; // Store for JavaScript mode
 
     if (useNative && MixpanelReactNative) {
@@ -689,8 +690,81 @@ export class Mixpanel {
    * need to call flush() to let the Mixpanel library know it should
    * send all remaining messages to the server.
    */
+  /**
+   * Returns the Autocapture instance for screen view tracking operations.
+   *
+   * @return {Autocapture} an instance of Autocapture that provides access to screen view tracking
+   *
+   * @see Autocapture
+   */
+  get autocapture() {
+    if (!this._autocapture) {
+      this._autocapture = new Autocapture(this.token, this.mixpanelImpl);
+    }
+    return this._autocapture;
+  }
+
   flush() {
     this.mixpanelImpl.flush(this.token);
+  }
+}
+
+/**
+ * Core class for using Mixpanel Autocapture features.
+ *
+ * <p>The Autocapture object is used to track screen views and screen leaves.
+ */
+export class Autocapture {
+  constructor(token, mixpanelImpl) {
+    if (!StringHelper.isValid(token)) {
+      StringHelper.raiseError(PARAMS.TOKEN);
+    }
+    this.token = token;
+    this.mixpanelImpl = mixpanelImpl;
+  }
+
+  /**
+   * Track a screen view event.
+   *
+   * @param {string} screenName The name of the screen being viewed
+   * @param {object} properties Optional additional properties to include with the event
+   */
+  trackScreenView(screenName, properties) {
+    if (!StringHelper.isValid(screenName)) {
+      return;
+    }
+    if (!ObjectHelper.isValidOrUndefined(properties)) {
+      ObjectHelper.raiseError(PARAMS.PROPERTIES);
+    }
+    const mergedProperties = {
+      ...Helper.getMetaData(),
+      ...properties,
+      current_page_title: screenName,
+      $mp_autocapture: true,
+    };
+    this.mixpanelImpl.trackScreenView(this.token, screenName, mergedProperties);
+  }
+
+  /**
+   * Track a screen leave event.
+   *
+   * @param {string} screenName The name of the screen being left
+   * @param {object} properties Optional additional properties to include with the event
+   */
+  trackScreenLeave(screenName, properties) {
+    if (!StringHelper.isValid(screenName)) {
+      return;
+    }
+    if (!ObjectHelper.isValidOrUndefined(properties)) {
+      ObjectHelper.raiseError(PARAMS.PROPERTIES);
+    }
+    const mergedProperties = {
+      ...Helper.getMetaData(),
+      ...properties,
+      current_page_title: screenName,
+      $mp_autocapture: true,
+    };
+    this.mixpanelImpl.trackScreenLeave(this.token, screenName, mergedProperties);
   }
 }
 

--- a/ios/MixpanelReactNative.m
+++ b/ios/MixpanelReactNative.m
@@ -30,6 +30,12 @@ RCT_EXTERN_METHOD(optInTracking:(NSString *)token resolver:(RCTPromiseResolveBlo
 
 RCT_EXTERN_METHOD(track:(NSString *)token event:(NSString *)event properties:(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - Autocapture
+
+RCT_EXTERN_METHOD(trackScreenView:(NSString *)token screenName:(NSString *)screenName properties:(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(trackScreenLeave:(NSString *)token screenName:(NSString *)screenName properties:(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 // MARK: - Timing Events
 
 RCT_EXTERN_METHOD(timeEvent:(NSString *)token event:(NSString *)event resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/MixpanelReactNative.swift
+++ b/ios/MixpanelReactNative.swift
@@ -165,6 +165,30 @@ open class MixpanelReactNative: NSObject {
         resolve(nil)
     }
 
+    // MARK: - Autocapture
+
+    @objc
+    func trackScreenView(_ token: String, screenName: String,
+                         properties: [String: Any]? = nil,
+                         resolver resolve: RCTPromiseResolveBlock,
+                         rejecter reject: RCTPromiseRejectBlock) -> Void {
+        let instance = MixpanelReactNative.getMixpanelInstance(token)
+        let mpProperties = MixpanelTypeHandler.processProperties(properties: properties)
+        instance?.autocapture.trackScreenView(screenName: screenName, properties: mpProperties)
+        resolve(nil)
+    }
+
+    @objc
+    func trackScreenLeave(_ token: String, screenName: String,
+                          properties: [String: Any]? = nil,
+                          resolver resolve: RCTPromiseResolveBlock,
+                          rejecter reject: RCTPromiseRejectBlock) -> Void {
+        let instance = MixpanelReactNative.getMixpanelInstance(token)
+        let mpProperties = MixpanelTypeHandler.processProperties(properties: properties)
+        instance?.autocapture.trackScreenLeave(screenName: screenName, properties: mpProperties)
+        resolve(nil)
+    }
+
     // MARK: - Timing Events
 
     @objc

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -559,6 +559,30 @@ export default class MixpanelMain {
     });
   }
 
+  async trackScreenView(token, screenName, properties) {
+    if (typeof screenName !== "string" || !screenName.trim()) {
+      return;
+    }
+    const mergedProperties = {
+      ...properties,
+      current_page_title: screenName,
+      $mp_autocapture: true,
+    };
+    await this.track(token, "$mp_page_view", mergedProperties);
+  }
+
+  async trackScreenLeave(token, screenName, properties) {
+    if (typeof screenName !== "string" || !screenName.trim()) {
+      return;
+    }
+    const mergedProperties = {
+      ...properties,
+      current_page_title: screenName,
+      $mp_autocapture: true,
+    };
+    await this.track(token, "$mp_page_leave", mergedProperties);
+  }
+
   async trackWithGroups(token, eventName, properties, groups) {
     MixpanelLogger.log(
       token,

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -560,13 +560,6 @@ export default class MixpanelMain {
   }
 
   async trackScreenView(token, screenName, properties) {
-    if (typeof screenName !== "string" || !screenName.trim()) {
-      MixpanelLogger.warn(
-        token,
-        `trackScreenView failed: screenName cannot be blank`
-      );
-      return;
-    }
     const mergedProperties = {
       ...properties,
       current_page_title: screenName,
@@ -576,13 +569,6 @@ export default class MixpanelMain {
   }
 
   async trackScreenLeave(token, screenName, properties) {
-    if (typeof screenName !== "string" || !screenName.trim()) {
-      MixpanelLogger.warn(
-        token,
-        `trackScreenLeave failed: screenName cannot be blank`
-      );
-      return;
-    }
     const mergedProperties = {
       ...properties,
       current_page_title: screenName,

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -560,6 +560,9 @@ export default class MixpanelMain {
   }
 
   async trackScreenView(token, screenName, properties) {
+    if (typeof screenName !== "string" || !screenName.trim()) {
+      return;
+    }
     const mergedProperties = {
       ...properties,
       current_page_title: screenName,
@@ -569,6 +572,9 @@ export default class MixpanelMain {
   }
 
   async trackScreenLeave(token, screenName, properties) {
+    if (typeof screenName !== "string" || !screenName.trim()) {
+      return;
+    }
     const mergedProperties = {
       ...properties,
       current_page_title: screenName,

--- a/javascript/mixpanel-main.js
+++ b/javascript/mixpanel-main.js
@@ -561,6 +561,10 @@ export default class MixpanelMain {
 
   async trackScreenView(token, screenName, properties) {
     if (typeof screenName !== "string" || !screenName.trim()) {
+      MixpanelLogger.warn(
+        token,
+        `trackScreenView failed: screenName cannot be blank`
+      );
       return;
     }
     const mergedProperties = {
@@ -573,6 +577,10 @@ export default class MixpanelMain {
 
   async trackScreenLeave(token, screenName, properties) {
     if (typeof screenName !== "string" || !screenName.trim()) {
+      MixpanelLogger.warn(
+        token,
+        `trackScreenLeave failed: screenName cannot be blank`
+      );
       return;
     }
     const mergedProperties = {


### PR DESCRIPTION
## Summary
- Adds `mixpanel.autocapture.trackScreenView(screenName, properties?)` and `mixpanel.autocapture.trackScreenLeave(screenName, properties?)` public APIs, mirroring the native Android/Swift SDK interfaces
- Implements native bridge methods for both Android (`getAutocapture().trackScreenView/trackScreenLeave`) and iOS (`autocapture.trackScreenView/trackScreenLeave`)
- Adds JS-mode fallback in `mixpanel-main.js` for Expo/web environments (tracks `$mp_page_view` / `$mp_page_leave` with `current_page_title` and `$mp_autocapture` properties)
- Updates sample app (`MixpanelStarter`) with navigation-based screen tracking using `onReady` and `onStateChange`

## Changes
- `index.js` — New `Autocapture` class with lazy getter on `Mixpanel`
- `index.d.ts` — TypeScript definitions for `Autocapture` class
- `android/.../MixpanelReactNativeModule.java` — `trackScreenView` and `trackScreenLeave` bridge methods
- `ios/MixpanelReactNative.swift` — Swift bridge implementations
- `ios/MixpanelReactNative.m` — ObjC extern method declarations
- `javascript/mixpanel-main.js` — JS-mode fallback implementation
- `Samples/MixpanelStarter/src/App.tsx` — Sample app screen tracking

## Test plan
- [x] All 291 unit tests pass
- [ ] Manual test on Android emulator — verify `$mp_page_view` and `$mp_page_leave` events fire on tab navigation
- [ ] Manual test on iOS simulator — verify events fire on tab navigation
- [ ] Verify `current_page_title` and `$mp_autocapture` properties are set by native SDK (not duplicated in JS layer)

Closes SDK-119