### PR TITLE
chore(analytics): document that screenName must be non-empty in trackScreenView/trackScreenLeave

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 type MixpanelType = any;
-type MixpanelProperties = {[key: string]: MixpanelType};
+type MixpanelProperties = { [key: string]: MixpanelType };
 
 export type MixpanelAsyncStorage = {
   getItem(key: string): Promise<string | null>;
@@ -60,46 +60,96 @@ export interface Flags {
   // Synchronous methods
   loadFlags(): Promise<void>;
   areFlagsReady(): boolean;
-  getVariantSync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
+  getVariantSync(
+    featureName: string,
+    fallback: MixpanelFlagVariant,
+  ): MixpanelFlagVariant;
   getVariantValueSync(featureName: string, fallbackValue: any): any;
   isEnabledSync(featureName: string, fallbackValue?: boolean): boolean;
   getAllVariantsSync(): Map<string, MixpanelFlagVariant>;
 
   // Asynchronous methods with overloads for callback and Promise patterns
-  getVariant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
-  getVariant(featureName: string, fallback: MixpanelFlagVariant, callback: (result: MixpanelFlagVariant) => void): void;
+  getVariant(
+    featureName: string,
+    fallback: MixpanelFlagVariant,
+  ): Promise<MixpanelFlagVariant>;
+  getVariant(
+    featureName: string,
+    fallback: MixpanelFlagVariant,
+    callback: (result: MixpanelFlagVariant) => void,
+  ): void;
 
   getVariantValue(featureName: string, fallbackValue: any): Promise<any>;
-  getVariantValue(featureName: string, fallbackValue: any, callback: (value: any) => void): void;
+  getVariantValue(
+    featureName: string,
+    fallbackValue: any,
+    callback: (value: any) => void,
+  ): void;
 
   isEnabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
-  isEnabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
+  isEnabled(
+    featureName: string,
+    fallbackValue: boolean,
+    callback: (isEnabled: boolean) => void,
+  ): void;
 
   getAllVariants(): Promise<Map<string, MixpanelFlagVariant>>;
-  getAllVariants(callback: (variants: Map<string, MixpanelFlagVariant>) => void): void;
+  getAllVariants(
+    callback: (variants: Map<string, MixpanelFlagVariant>) => void,
+  ): void;
 
   // Context management — available in both native and JavaScript modes.
-  updateContext(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
+  updateContext(
+    newContext: MixpanelProperties,
+    options?: UpdateContextOptions,
+  ): Promise<void>;
 
   // First-time event hook (JavaScript mode only; native mode is a no-op).
-  checkFirstTimeEvents(eventName: string, properties?: MixpanelProperties): void;
+  checkFirstTimeEvents(
+    eventName: string,
+    properties?: MixpanelProperties,
+  ): void;
 
   // snake_case aliases
   are_flags_ready(): boolean;
-  get_variant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
-  get_variant(featureName: string, fallback: MixpanelFlagVariant, callback: (result: MixpanelFlagVariant) => void): void;
-  get_variant_sync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
+  get_variant(
+    featureName: string,
+    fallback: MixpanelFlagVariant,
+  ): Promise<MixpanelFlagVariant>;
+  get_variant(
+    featureName: string,
+    fallback: MixpanelFlagVariant,
+    callback: (result: MixpanelFlagVariant) => void,
+  ): void;
+  get_variant_sync(
+    featureName: string,
+    fallback: MixpanelFlagVariant,
+  ): MixpanelFlagVariant;
   get_variant_value(featureName: string, fallbackValue: any): Promise<any>;
-  get_variant_value(featureName: string, fallbackValue: any, callback: (value: any) => void): void;
+  get_variant_value(
+    featureName: string,
+    fallbackValue: any,
+    callback: (value: any) => void,
+  ): void;
   get_variant_value_sync(featureName: string, fallbackValue: any): any;
   is_enabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
-  is_enabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
+  is_enabled(
+    featureName: string,
+    fallbackValue: boolean,
+    callback: (isEnabled: boolean) => void,
+  ): void;
   is_enabled_sync(featureName: string, fallbackValue?: boolean): boolean;
   get_all_variants(): Promise<Map<string, MixpanelFlagVariant>>;
   get_all_variants_sync(): Map<string, MixpanelFlagVariant>;
   load_flags(): Promise<void>;
-  update_context(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
-  check_first_time_events(eventName: string, properties?: MixpanelProperties): void;
+  update_context(
+    newContext: MixpanelProperties,
+    options?: UpdateContextOptions,
+  ): Promise<void>;
+  check_first_time_events(
+    eventName: string,
+    properties?: MixpanelProperties,
+  ): void;
 }
 
 export class Autocapture {
@@ -131,19 +181,19 @@ export class Mixpanel {
     token: string,
     trackAutomaticEvents: boolean,
     useNative: false,
-    storage?: MixpanelAsyncStorage
+    storage?: MixpanelAsyncStorage,
   );
   static init(
     token: string,
     trackAutomaticEvents: boolean,
-    optOutTrackingDefault?: boolean
+    optOutTrackingDefault?: boolean,
   ): Promise<Mixpanel>;
   init(
     optOutTrackingDefault?: boolean,
     superProperties?: MixpanelProperties,
     serverURL?: string,
     useGzipCompression?: boolean,
-    featureFlagsOptions?: FeatureFlagsOptions
+    featureFlagsOptions?: FeatureFlagsOptions,
   ): Promise<void>;
   setServerURL(serverURL: string): void;
   setLoggingEnabled(loggingEnabled: boolean): void;
@@ -160,7 +210,7 @@ export class Mixpanel {
   trackWithGroups(
     eventName: string,
     properties?: MixpanelProperties,
-    groups?: MixpanelProperties
+    groups?: MixpanelProperties,
   ): void;
   setGroup(groupKey: string, groupID: MixpanelType): void;
   getGroup(groupKey: string, groupID: MixpanelType): MixpanelGroup;
@@ -202,7 +252,7 @@ export class MixpanelGroup {
     token: string,
     groupKey: string,
     groupID: MixpanelType,
-    mixpanelInstance: any
+    mixpanelInstance: any,
   );
   set(prop: string, to: MixpanelType): void;
   setOnce(prop: string, to: MixpanelType): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 type MixpanelType = any;
-type MixpanelProperties = { [key: string]: MixpanelType };
+type MixpanelProperties = {[key: string]: MixpanelType};
 
 export type MixpanelAsyncStorage = {
   getItem(key: string): Promise<string | null>;
@@ -60,96 +60,46 @@ export interface Flags {
   // Synchronous methods
   loadFlags(): Promise<void>;
   areFlagsReady(): boolean;
-  getVariantSync(
-    featureName: string,
-    fallback: MixpanelFlagVariant,
-  ): MixpanelFlagVariant;
+  getVariantSync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
   getVariantValueSync(featureName: string, fallbackValue: any): any;
   isEnabledSync(featureName: string, fallbackValue?: boolean): boolean;
   getAllVariantsSync(): Map<string, MixpanelFlagVariant>;
 
   // Asynchronous methods with overloads for callback and Promise patterns
-  getVariant(
-    featureName: string,
-    fallback: MixpanelFlagVariant,
-  ): Promise<MixpanelFlagVariant>;
-  getVariant(
-    featureName: string,
-    fallback: MixpanelFlagVariant,
-    callback: (result: MixpanelFlagVariant) => void,
-  ): void;
+  getVariant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
+  getVariant(featureName: string, fallback: MixpanelFlagVariant, callback: (result: MixpanelFlagVariant) => void): void;
 
   getVariantValue(featureName: string, fallbackValue: any): Promise<any>;
-  getVariantValue(
-    featureName: string,
-    fallbackValue: any,
-    callback: (value: any) => void,
-  ): void;
+  getVariantValue(featureName: string, fallbackValue: any, callback: (value: any) => void): void;
 
   isEnabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
-  isEnabled(
-    featureName: string,
-    fallbackValue: boolean,
-    callback: (isEnabled: boolean) => void,
-  ): void;
+  isEnabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
 
   getAllVariants(): Promise<Map<string, MixpanelFlagVariant>>;
-  getAllVariants(
-    callback: (variants: Map<string, MixpanelFlagVariant>) => void,
-  ): void;
+  getAllVariants(callback: (variants: Map<string, MixpanelFlagVariant>) => void): void;
 
   // Context management — available in both native and JavaScript modes.
-  updateContext(
-    newContext: MixpanelProperties,
-    options?: UpdateContextOptions,
-  ): Promise<void>;
+  updateContext(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
 
   // First-time event hook (JavaScript mode only; native mode is a no-op).
-  checkFirstTimeEvents(
-    eventName: string,
-    properties?: MixpanelProperties,
-  ): void;
+  checkFirstTimeEvents(eventName: string, properties?: MixpanelProperties): void;
 
   // snake_case aliases
   are_flags_ready(): boolean;
-  get_variant(
-    featureName: string,
-    fallback: MixpanelFlagVariant,
-  ): Promise<MixpanelFlagVariant>;
-  get_variant(
-    featureName: string,
-    fallback: MixpanelFlagVariant,
-    callback: (result: MixpanelFlagVariant) => void,
-  ): void;
-  get_variant_sync(
-    featureName: string,
-    fallback: MixpanelFlagVariant,
-  ): MixpanelFlagVariant;
+  get_variant(featureName: string, fallback: MixpanelFlagVariant): Promise<MixpanelFlagVariant>;
+  get_variant(featureName: string, fallback: MixpanelFlagVariant, callback: (result: MixpanelFlagVariant) => void): void;
+  get_variant_sync(featureName: string, fallback: MixpanelFlagVariant): MixpanelFlagVariant;
   get_variant_value(featureName: string, fallbackValue: any): Promise<any>;
-  get_variant_value(
-    featureName: string,
-    fallbackValue: any,
-    callback: (value: any) => void,
-  ): void;
+  get_variant_value(featureName: string, fallbackValue: any, callback: (value: any) => void): void;
   get_variant_value_sync(featureName: string, fallbackValue: any): any;
   is_enabled(featureName: string, fallbackValue?: boolean): Promise<boolean>;
-  is_enabled(
-    featureName: string,
-    fallbackValue: boolean,
-    callback: (isEnabled: boolean) => void,
-  ): void;
+  is_enabled(featureName: string, fallbackValue: boolean, callback: (isEnabled: boolean) => void): void;
   is_enabled_sync(featureName: string, fallbackValue?: boolean): boolean;
   get_all_variants(): Promise<Map<string, MixpanelFlagVariant>>;
   get_all_variants_sync(): Map<string, MixpanelFlagVariant>;
   load_flags(): Promise<void>;
-  update_context(
-    newContext: MixpanelProperties,
-    options?: UpdateContextOptions,
-  ): Promise<void>;
-  check_first_time_events(
-    eventName: string,
-    properties?: MixpanelProperties,
-  ): void;
+  update_context(newContext: MixpanelProperties, options?: UpdateContextOptions): Promise<void>;
+  check_first_time_events(eventName: string, properties?: MixpanelProperties): void;
 }
 
 export class Autocapture {
@@ -181,19 +131,19 @@ export class Mixpanel {
     token: string,
     trackAutomaticEvents: boolean,
     useNative: false,
-    storage?: MixpanelAsyncStorage,
+    storage?: MixpanelAsyncStorage
   );
   static init(
     token: string,
     trackAutomaticEvents: boolean,
-    optOutTrackingDefault?: boolean,
+    optOutTrackingDefault?: boolean
   ): Promise<Mixpanel>;
   init(
     optOutTrackingDefault?: boolean,
     superProperties?: MixpanelProperties,
     serverURL?: string,
     useGzipCompression?: boolean,
-    featureFlagsOptions?: FeatureFlagsOptions,
+    featureFlagsOptions?: FeatureFlagsOptions
   ): Promise<void>;
   setServerURL(serverURL: string): void;
   setLoggingEnabled(loggingEnabled: boolean): void;
@@ -210,7 +160,7 @@ export class Mixpanel {
   trackWithGroups(
     eventName: string,
     properties?: MixpanelProperties,
-    groups?: MixpanelProperties,
+    groups?: MixpanelProperties
   ): void;
   setGroup(groupKey: string, groupID: MixpanelType): void;
   getGroup(groupKey: string, groupID: MixpanelType): MixpanelGroup;
@@ -252,7 +202,7 @@ export class MixpanelGroup {
     token: string,
     groupKey: string,
     groupID: MixpanelType,
-    mixpanelInstance: any,
+    mixpanelInstance: any
   );
   set(prop: string, to: MixpanelType): void;
   setOnce(prop: string, to: MixpanelType): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,21 @@ export interface Flags {
 }
 
 export class Autocapture {
+  /**
+   * Track a screen view event.
+   *
+   * @param screenName The name of the screen being viewed. Must be non-empty;
+   *   if an empty or whitespace-only string is passed, the event is silently dropped.
+   * @param properties Optional additional properties to include with the event
+   */
   trackScreenView(screenName: string, properties?: MixpanelProperties): void;
+  /**
+   * Track a screen leave event.
+   *
+   * @param screenName The name of the screen being left. Must be non-empty;
+   *   if an empty or whitespace-only string is passed, the event is silently dropped.
+   * @param properties Optional additional properties to include with the event
+   */
   trackScreenLeave(screenName: string, properties?: MixpanelProperties): void;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
-import { Platform, NativeModules } from "react-native";
+import {Platform, NativeModules} from "react-native";
 import packageJson from "./package.json";
-const { MixpanelReactNative } = NativeModules;
-import MixpanelMain from "mixpanel-react-native/javascript/mixpanel-main";
-import { MixpanelLogger } from "mixpanel-react-native/javascript/mixpanel-logger";
+const {MixpanelReactNative} = NativeModules;
+import MixpanelMain from "mixpanel-react-native/javascript/mixpanel-main"
+import { MixpanelLogger } from "mixpanel-react-native/javascript/mixpanel-logger"
 
 const DevicePlatform = {
   Unknown: "Unknown",
@@ -56,7 +56,7 @@ export class Mixpanel {
       return;
     } else if (useNative) {
       console.warn(
-        "MixpanelReactNative is not available; using JavaScript mode. If you prefer not to use the JavaScript mode, please follow the guide in the GitHub repository: https://github.com/mixpanel/mixpanel-react-native.",
+        "MixpanelReactNative is not available; using JavaScript mode. If you prefer not to use the JavaScript mode, please follow the guide in the GitHub repository: https://github.com/mixpanel/mixpanel-react-native."
       );
     }
 
@@ -93,8 +93,8 @@ export class Mixpanel {
         MixpanelLogger.warn(
           this.token,
           "Accessing feature flags API but flags are not enabled. " +
-            "Call init() with featureFlagsOptions.enabled = true to enable feature flags. " +
-            "Flag methods will return fallback values.",
+          "Call init() with featureFlagsOptions.enabled = true to enable feature flags. " +
+          "Flag methods will return fallback values."
         );
       }
       // Lazy load the Flags instance with proper dependencies
@@ -175,7 +175,7 @@ export class Mixpanel {
     superProperties = {},
     serverURL = "https://api.mixpanel.com",
     useGzipCompression = false,
-    featureFlagsOptions = {},
+    featureFlagsOptions = {}
   ) {
     // Store feature flags options for later use
     this.featureFlagsOptions = featureFlagsOptions;
@@ -184,19 +184,16 @@ export class Mixpanel {
       this.token,
       this.trackAutomaticEvents,
       optOutTrackingDefault,
-      { ...Helper.getMetaData(), ...superProperties },
+      {...Helper.getMetaData(), ...superProperties},
       serverURL,
       useGzipCompression,
-      featureFlagsOptions,
+      featureFlagsOptions
     );
 
     // If flags are enabled AND we're in native mode, initialize them
-    if (
-      featureFlagsOptions.enabled &&
-      this.mixpanelImpl === MixpanelReactNative
-    ) {
+    if (featureFlagsOptions.enabled && this.mixpanelImpl === MixpanelReactNative) {
       await this.flags.loadFlags();
-    }
+  }
   }
 
   /**
@@ -218,7 +215,7 @@ export class Mixpanel {
   static async init(
     token,
     trackAutomaticEvents,
-    optOutTrackingDefault = DEFAULT_OPT_OUT,
+    optOutTrackingDefault = DEFAULT_OPT_OUT
   ) {
     await MixpanelReactNative.initialize(
       token,
@@ -227,7 +224,7 @@ export class Mixpanel {
       Helper.getMetaData(),
       "https://api.mixpanel.com",
       false,
-      {},
+      {}
     );
     return new Mixpanel(token, trackAutomaticEvents);
   }
@@ -270,7 +267,7 @@ export class Mixpanel {
       MixpanelReactNative.setFlushOnBackground(this.token, flushOnBackground);
     } else {
       console.warn(
-        "Mixpanel setFlushOnBackground was called and ignored because this method only works on iOS.",
+        "Mixpanel setFlushOnBackground was called and ignored because this method only works on iOS."
       );
     }
   }
@@ -287,7 +284,7 @@ export class Mixpanel {
   setUseIpAddressForGeolocation(useIpAddressForGeolocation) {
     this.mixpanelImpl.setUseIpAddressForGeolocation(
       this.token,
-      useIpAddressForGeolocation,
+      useIpAddressForGeolocation
     );
   }
 
@@ -462,7 +459,7 @@ export class Mixpanel {
         ...Helper.getMetaData(),
         ...properties,
       },
-      groups,
+      groups
     );
   }
 
@@ -496,7 +493,7 @@ export class Mixpanel {
         this.token,
         groupKey,
         groupID,
-        this.mixpanelImpl,
+        this.mixpanelImpl
       );
       return this.group;
     }
@@ -737,7 +734,7 @@ export class Autocapture {
     if (!StringHelper.isValid(screenName)) {
       MixpanelLogger.warn(
         this.token,
-        `trackScreenView failed: screenName cannot be blank`,
+        `trackScreenView failed: screenName cannot be blank`
       );
       return;
     }
@@ -762,7 +759,7 @@ export class Autocapture {
     if (!StringHelper.isValid(screenName)) {
       MixpanelLogger.warn(
         this.token,
-        `trackScreenLeave failed: screenName cannot be blank`,
+        `trackScreenLeave failed: screenName cannot be blank`
       );
       return;
     }
@@ -773,11 +770,7 @@ export class Autocapture {
       ...Helper.getMetaData(),
       ...properties,
     };
-    this.mixpanelImpl.trackScreenLeave(
-      this.token,
-      screenName,
-      mergedProperties,
-    );
+    this.mixpanelImpl.trackScreenLeave(this.token, screenName, mergedProperties);
   }
 }
 
@@ -858,7 +851,7 @@ export class People {
         var val = prop[key];
         if (isNaN(parseFloat(val))) {
           throw new Error(
-            `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`,
+            `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`
           );
         }
         add[key] = val;
@@ -867,7 +860,7 @@ export class People {
       by = by || 1;
       if (isNaN(parseFloat(by))) {
         throw new Error(
-          `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`,
+          `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`
         );
       }
 
@@ -918,8 +911,8 @@ export class People {
     value = Array.isArray(value) ? value : [value];
 
     if (DevicePlatform.iOS === Helper.getDevicePlatform()) {
-      this.mixpanelImpl.union(this.token, { [name]: value });
-      this.mixpanelImpl.union(this.token, { [name]: value });
+      this.mixpanelImpl.union(this.token, {[name]: value});
+      this.mixpanelImpl.union(this.token, {[name]: value});
     } else {
       this.mixpanelImpl.union(this.token, name, value);
     }
@@ -1031,7 +1024,7 @@ export class MixpanelGroup {
       this.token,
       this.groupKey,
       this.groupID,
-      properties,
+      properties
     );
   }
 
@@ -1055,7 +1048,7 @@ export class MixpanelGroup {
       this.token,
       this.groupKey,
       this.groupID,
-      properties,
+      properties
     );
   }
 
@@ -1072,7 +1065,7 @@ export class MixpanelGroup {
       this.token,
       this.groupKey,
       this.groupID,
-      prop,
+      prop
     );
   }
 
@@ -1094,7 +1087,7 @@ export class MixpanelGroup {
       this.groupKey,
       this.groupID,
       name,
-      value,
+      value
     );
   }
 
@@ -1116,7 +1109,7 @@ export class MixpanelGroup {
       this.groupKey,
       this.groupID,
       name,
-      value,
+      value
     );
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
-import {Platform, NativeModules} from "react-native";
+import { Platform, NativeModules } from "react-native";
 import packageJson from "./package.json";
-const {MixpanelReactNative} = NativeModules;
-import MixpanelMain from "mixpanel-react-native/javascript/mixpanel-main"
-import { MixpanelLogger } from "mixpanel-react-native/javascript/mixpanel-logger"
+const { MixpanelReactNative } = NativeModules;
+import MixpanelMain from "mixpanel-react-native/javascript/mixpanel-main";
+import { MixpanelLogger } from "mixpanel-react-native/javascript/mixpanel-logger";
 
 const DevicePlatform = {
   Unknown: "Unknown",
@@ -56,7 +56,7 @@ export class Mixpanel {
       return;
     } else if (useNative) {
       console.warn(
-        "MixpanelReactNative is not available; using JavaScript mode. If you prefer not to use the JavaScript mode, please follow the guide in the GitHub repository: https://github.com/mixpanel/mixpanel-react-native."
+        "MixpanelReactNative is not available; using JavaScript mode. If you prefer not to use the JavaScript mode, please follow the guide in the GitHub repository: https://github.com/mixpanel/mixpanel-react-native.",
       );
     }
 
@@ -93,8 +93,8 @@ export class Mixpanel {
         MixpanelLogger.warn(
           this.token,
           "Accessing feature flags API but flags are not enabled. " +
-          "Call init() with featureFlagsOptions.enabled = true to enable feature flags. " +
-          "Flag methods will return fallback values."
+            "Call init() with featureFlagsOptions.enabled = true to enable feature flags. " +
+            "Flag methods will return fallback values.",
         );
       }
       // Lazy load the Flags instance with proper dependencies
@@ -175,7 +175,7 @@ export class Mixpanel {
     superProperties = {},
     serverURL = "https://api.mixpanel.com",
     useGzipCompression = false,
-    featureFlagsOptions = {}
+    featureFlagsOptions = {},
   ) {
     // Store feature flags options for later use
     this.featureFlagsOptions = featureFlagsOptions;
@@ -184,16 +184,19 @@ export class Mixpanel {
       this.token,
       this.trackAutomaticEvents,
       optOutTrackingDefault,
-      {...Helper.getMetaData(), ...superProperties},
+      { ...Helper.getMetaData(), ...superProperties },
       serverURL,
       useGzipCompression,
-      featureFlagsOptions
+      featureFlagsOptions,
     );
 
     // If flags are enabled AND we're in native mode, initialize them
-    if (featureFlagsOptions.enabled && this.mixpanelImpl === MixpanelReactNative) {
+    if (
+      featureFlagsOptions.enabled &&
+      this.mixpanelImpl === MixpanelReactNative
+    ) {
       await this.flags.loadFlags();
-  }
+    }
   }
 
   /**
@@ -215,7 +218,7 @@ export class Mixpanel {
   static async init(
     token,
     trackAutomaticEvents,
-    optOutTrackingDefault = DEFAULT_OPT_OUT
+    optOutTrackingDefault = DEFAULT_OPT_OUT,
   ) {
     await MixpanelReactNative.initialize(
       token,
@@ -224,7 +227,7 @@ export class Mixpanel {
       Helper.getMetaData(),
       "https://api.mixpanel.com",
       false,
-      {}
+      {},
     );
     return new Mixpanel(token, trackAutomaticEvents);
   }
@@ -267,7 +270,7 @@ export class Mixpanel {
       MixpanelReactNative.setFlushOnBackground(this.token, flushOnBackground);
     } else {
       console.warn(
-        "Mixpanel setFlushOnBackground was called and ignored because this method only works on iOS."
+        "Mixpanel setFlushOnBackground was called and ignored because this method only works on iOS.",
       );
     }
   }
@@ -284,7 +287,7 @@ export class Mixpanel {
   setUseIpAddressForGeolocation(useIpAddressForGeolocation) {
     this.mixpanelImpl.setUseIpAddressForGeolocation(
       this.token,
-      useIpAddressForGeolocation
+      useIpAddressForGeolocation,
     );
   }
 
@@ -459,7 +462,7 @@ export class Mixpanel {
         ...Helper.getMetaData(),
         ...properties,
       },
-      groups
+      groups,
     );
   }
 
@@ -493,7 +496,7 @@ export class Mixpanel {
         this.token,
         groupKey,
         groupID,
-        this.mixpanelImpl
+        this.mixpanelImpl,
       );
       return this.group;
     }
@@ -734,7 +737,7 @@ export class Autocapture {
     if (!StringHelper.isValid(screenName)) {
       MixpanelLogger.warn(
         this.token,
-        `trackScreenView failed: screenName cannot be blank`
+        `trackScreenView failed: screenName cannot be blank`,
       );
       return;
     }
@@ -759,7 +762,7 @@ export class Autocapture {
     if (!StringHelper.isValid(screenName)) {
       MixpanelLogger.warn(
         this.token,
-        `trackScreenLeave failed: screenName cannot be blank`
+        `trackScreenLeave failed: screenName cannot be blank`,
       );
       return;
     }
@@ -770,7 +773,11 @@ export class Autocapture {
       ...Helper.getMetaData(),
       ...properties,
     };
-    this.mixpanelImpl.trackScreenLeave(this.token, screenName, mergedProperties);
+    this.mixpanelImpl.trackScreenLeave(
+      this.token,
+      screenName,
+      mergedProperties,
+    );
   }
 }
 
@@ -851,7 +858,7 @@ export class People {
         var val = prop[key];
         if (isNaN(parseFloat(val))) {
           throw new Error(
-            `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`
+            `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`,
           );
         }
         add[key] = val;
@@ -860,7 +867,7 @@ export class People {
       by = by || 1;
       if (isNaN(parseFloat(by))) {
         throw new Error(
-          `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`
+          `${PARAMS.PROPERTY_VALUE}${ERROR_MESSAGE.REQUIRED_DOUBLE}`,
         );
       }
 
@@ -911,8 +918,8 @@ export class People {
     value = Array.isArray(value) ? value : [value];
 
     if (DevicePlatform.iOS === Helper.getDevicePlatform()) {
-      this.mixpanelImpl.union(this.token, {[name]: value});
-      this.mixpanelImpl.union(this.token, {[name]: value});
+      this.mixpanelImpl.union(this.token, { [name]: value });
+      this.mixpanelImpl.union(this.token, { [name]: value });
     } else {
       this.mixpanelImpl.union(this.token, name, value);
     }
@@ -1024,7 +1031,7 @@ export class MixpanelGroup {
       this.token,
       this.groupKey,
       this.groupID,
-      properties
+      properties,
     );
   }
 
@@ -1048,7 +1055,7 @@ export class MixpanelGroup {
       this.token,
       this.groupKey,
       this.groupID,
-      properties
+      properties,
     );
   }
 
@@ -1065,7 +1072,7 @@ export class MixpanelGroup {
       this.token,
       this.groupKey,
       this.groupID,
-      prop
+      prop,
     );
   }
 
@@ -1087,7 +1094,7 @@ export class MixpanelGroup {
       this.groupKey,
       this.groupID,
       name,
-      value
+      value,
     );
   }
 
@@ -1109,7 +1116,7 @@ export class MixpanelGroup {
       this.groupKey,
       this.groupID,
       name,
-      value
+      value,
     );
   }
 }

--- a/index.js
+++ b/index.js
@@ -726,7 +726,8 @@ export class Autocapture {
   /**
    * Track a screen view event.
    *
-   * @param {string} screenName The name of the screen being viewed
+   * @param {string} screenName The name of the screen being viewed. Must be non-empty;
+   *   if an empty or whitespace-only string is passed, the event is silently dropped.
    * @param {object} properties Optional additional properties to include with the event
    */
   trackScreenView(screenName, properties) {
@@ -750,7 +751,8 @@ export class Autocapture {
   /**
    * Track a screen leave event.
    *
-   * @param {string} screenName The name of the screen being left
+   * @param {string} screenName The name of the screen being left. Must be non-empty;
+   *   if an empty or whitespace-only string is passed, the event is silently dropped.
    * @param {object} properties Optional additional properties to include with the event
    */
   trackScreenLeave(screenName, properties) {


### PR DESCRIPTION
## Summary
- Update JSDoc on `screenName` param for `trackScreenView` and `trackScreenLeave` in `index.js` stating it must be non-empty and the event is silently dropped if empty/whitespace-only.
- Add JSDoc to TypeScript definitions in `index.d.ts` for the same methods.
- Run prettier on changed files.

## Test plan
- [ ] Verify JSDoc renders correctly in IDE hover tooltips

SDK-142