### PR TITLE
feat: document the current $el_id resolution rules in both sample apps

### DIFF
--- a/Samples/MixpanelExpo/App.js
+++ b/Samples/MixpanelExpo/App.js
@@ -13,8 +13,16 @@ import { Mixpanel } from "mixpanel-react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { MIXPANEL_TOKEN } from "@env";
 
+import { AutocaptureTestScreen } from "./screens/AutocaptureTestScreen";
+
 const App = () => {
   const [isInitialized, setIsInitialized] = useState(false);
+  // Swaps the SDK action list for the autocapture test screen. A plain toggle rather than a
+  // navigator: this sample has no navigation stack, and adding one would pull in four
+  // dependencies and change the view hierarchy that autocapture reports — the structural
+  // hash behind `$el_id` is derived from a view's ancestors, so wrapping the screen in a
+  // navigator would re-key every hash-based id this screen documents.
+  const [showAutocaptureTests, setShowAutocaptureTests] = useState(false);
   const mixpanelRef = useRef(null);
 
   // Test flag name - replace with your actual flag from Mixpanel
@@ -444,8 +452,30 @@ const App = () => {
     <Text style={styles.header}>{title}</Text>
   );
 
+  if (showAutocaptureTests) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.item}>
+          <Button
+            title="← Back to SDK actions"
+            onPress={() => setShowAutocaptureTests(false)}
+            color="#8A2BE2"
+          />
+        </View>
+        <AutocaptureTestScreen />
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView style={styles.container}>
+      <View style={styles.item}>
+        <Button
+          title="Autocapture test screen →"
+          onPress={() => setShowAutocaptureTests(true)}
+          color="#8A2BE2"
+        />
+      </View>
       <SectionList
         sections={DATA}
         keyExtractor={(item, index) => item.id}

--- a/Samples/MixpanelExpo/App.js
+++ b/Samples/MixpanelExpo/App.js
@@ -31,6 +31,12 @@ const App = () => {
   useEffect(() => {
     const initMixpanel = async () => {
       const trackAutomaticEvents = false;
+      // Autocapture requires native mode. It lives entirely in the native Android and iOS
+      // SDKs, so with useNative = false there is nothing to forward configuration to: the
+      // autocaptureOptions argument to init() is ignored and only a startup warning is
+      // logged. Set this to true — and pass autocaptureOptions below — to exercise the
+      // autocapture test screen. Doing so rules out Expo Go, which cannot load custom
+      // native modules; a development build or prebuild is required.
       const useNative = false;
       // Pass AsyncStorage for JavaScript mode feature flags support
       const mp = new Mixpanel(MIXPANEL_TOKEN, trackAutomaticEvents, useNative, AsyncStorage);

--- a/Samples/MixpanelExpo/screens/AutocaptureTestScreen.js
+++ b/Samples/MixpanelExpo/screens/AutocaptureTestScreen.js
@@ -1,0 +1,311 @@
+import React, {useState} from 'react';
+import {
+  Platform,
+  ScrollView,
+  View,
+  Text,
+  TouchableOpacity,
+  Pressable,
+  Switch,
+  TextInput,
+  StyleSheet,
+} from 'react-native';
+
+export function AutocaptureTestScreen() {
+  const [tapCount, setTapCount] = useState(0);
+  const [switchValue, setSwitchValue] = useState(false);
+  const [textValue, setTextValue] = useState('');
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Autocapture Test Screen</Text>
+      <Text style={styles.subtitle}>
+        Run on both iOS and Android. Inspect Mixpanel event stream to verify.
+      </Text>
+
+      {/* ============================================================
+          $el_id Resolution
+
+          What each native SDK does with the props below.
+
+          Android — View path (this is the path React Native uses):
+            1. nativeID           — RN stores the prop as a view tag
+            2. Resource entry name — getResourceEntryName(view.getId());
+               RN's ids are generated at runtime and have no entry name,
+               so testID never resolves here
+            3. <SimpleClassName>_<hash>
+
+          iOS — one path for UIKit and SwiftUI:
+            1. nativeID            — RN exposes it as an ObjC property
+            2. accessibilityIdentifier — RN: testID
+            3. <ClassName>_<hash>
+
+          accessibilityLabel is NOT used, on either platform. It is
+          localized — the same element would report a different id per
+          language — and it can carry user data. It is not reported as a
+          property either: there is no $attr-aria-label.
+
+          The hash is not random: it is derived from the element's position
+          in the hierarchy, so it stays the same across launches for the
+          same layout. It identifies a position, not a row — reordering
+          siblings changes it.
+
+          The one prop that behaves identically on both platforms is
+          nativeID. testID diverges: stable $el_id on iOS, hash on Android.
+
+          NOTE: in a React Native *debug* build every tap resolves to RN's
+          full-screen DebuggingOverlay, so none of these are observable —
+          verify against a release build.
+          ============================================================ */}
+      <SectionHeader title="$el_id Resolution" />
+
+      {/* Case 1: nativeID only — priority 1 on both platforms.
+          `id` is React Native's modern alias: the JS layer copies it onto
+          nativeID (react-native/Libraries/Components/View/View.js), and unlike
+          `nativeID` it is typed on Touchable components. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        id="rn_native_id_btn">
+        <Text>nativeID only</Text>
+        <Expect ios="rn_native_id_btn" android="rn_native_id_btn" />
+      </TouchableOpacity>
+
+      {/* Case 2: nativeID beats everything else, on both platforms. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        id="rn_wins_btn"
+        testID="tid_ignored_btn"
+        accessible={true}
+        accessibilityLabel="al_ignored_btn">
+        <Text>nativeID + testID + accessibilityLabel</Text>
+        <Expect ios="rn_wins_btn" android="rn_wins_btn" />
+      </TouchableOpacity>
+
+      {/* Case 3: testID only — the platform divergence.
+          iOS maps testID to accessibilityIdentifier (priority 2); on Android
+          RN's runtime-generated id has no resource entry name, so the SDK
+          falls through to the structural hash. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={false}
+        testID="tid_only_btn">
+        <Text>testID only</Text>
+        <Expect ios="tid_only_btn" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 4: testID + accessibilityLabel. The label is never a source, so
+          iOS uses the identifier and Android — which cannot resolve RN's id —
+          falls to the hash. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        testID="tid_beats_label_btn"
+        accessibilityLabel="al_never_used">
+        <Text>testID + accessibilityLabel</Text>
+        <Expect ios="tid_beats_label_btn" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 5: accessibilityLabel only — never used as identity, on either
+          platform, and never reported as a property. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        accessibilityLabel="al_only_btn">
+        <Text>accessibilityLabel only (never used)</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 6: a label holding user data. Nothing about it reaches the
+          payload — not $el_id, and there is no $attr-aria-label at all. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        accessibilityLabel="Account ending 4321">
+        <Text>label with user data (PII guard)</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 7: no explicit label, only child text. Frameworks auto-derive a
+          container label from it; that must not surface either. */}
+      <TouchableOpacity style={styles.btn} onPress={() => {}} accessible={false}>
+        <Text>auto-derived label from child text — 4111 1111 1111 1234</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 8: nothing to identify the element — structural hash. Tap it
+          twice across app launches: the id should be the same both times. */}
+      <TouchableOpacity style={styles.btn} onPress={() => {}} accessible={false}>
+        <Text>No nativeID, no testID, no label</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 9: Pressable carrying a nativeID — same result as
+          TouchableOpacity; resolution is per-view, not per-component. */}
+      <Pressable style={styles.btn} onPress={() => {}} id="pressable_native_id">
+        <Text>Pressable + nativeID</Text>
+        <Expect ios="pressable_native_id" android="pressable_native_id" />
+      </Pressable>
+
+      {/* Case 10: label on a non-interactive child, nothing on the parent.
+          Both SDKs walk up to the nearest clickable ancestor and resolve from
+          there, so identity comes from the parent — which here has none. */}
+      <TouchableOpacity style={styles.btn} onPress={() => {}}>
+        <Text accessible={true} accessibilityLabel="child_text_al">
+          Label on child Text (not on the parent)
+        </Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* ============================================================
+          Click
+          ============================================================ */}
+      <SectionHeader title="Click" />
+
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        accessibilityLabel="click_btn">
+        <Text>Click Button - tap once → $mp_click</Text>
+      </TouchableOpacity>
+
+      {/* ============================================================
+          Dead Click
+          ============================================================ */}
+      <SectionHeader title="Dead Click" />
+
+      <View
+        style={[styles.btn, styles.deadBtn]}
+        accessible={true}
+        accessibilityLabel="dead_rn_btn"
+        accessibilityRole="button">
+        <Text>Dead Button (no onPress) → $mp_dead_click</Text>
+      </View>
+
+      {/* ============================================================
+          Rage Click - tap 4+ times rapidly
+          ============================================================ */}
+      <SectionHeader title="Rage Click - tap 4+ times rapidly" />
+
+      <View
+        style={[styles.btn, styles.rageZone]}
+        accessible={true}
+        accessibilityLabel="rage_zone"
+        accessibilityRole="button">
+        <Text>Rage Zone - tap rapidly (no state change)</Text>
+      </View>
+
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => setTapCount(c => c + 1)}
+        accessible={true}
+        accessibilityLabel="rage_and_click_btn">
+        <Text>
+          Click + Rage - tap 4x (both events): {tapCount}x
+        </Text>
+      </TouchableOpacity>
+
+      {/* ============================================================
+          Excluded Controls (no dead click)
+          ============================================================ */}
+      <SectionHeader title="Excluded Controls (no dead click)" />
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Switch</Text>
+        <Switch value={switchValue} onValueChange={setSwitchValue} />
+      </View>
+
+      <TextInput
+        style={styles.input}
+        placeholder="TextInput - no dead click"
+        value={textValue}
+        onChangeText={setTextValue}
+        accessibilityLabel="text_input"
+      />
+    </ScrollView>
+  );
+}
+
+/**
+ * Renders the $el_id each platform is expected to report for the case above it,
+ * highlighting whichever platform the app is currently running on. Keeps the
+ * expectations next to the props that produce them, so a mismatch in the event
+ * stream is obvious without cross-referencing the SDK source.
+ */
+function Expect({ios, android}) {
+  const isIOS = Platform.OS === 'ios';
+  return (
+    <Text style={styles.expect}>
+      <Text style={isIOS ? styles.expectActive : undefined}>iOS: {ios}</Text>
+      {'  ·  '}
+      <Text style={isIOS ? undefined : styles.expectActive}>
+        Android: {android}
+      </Text>
+    </Text>
+  );
+}
+
+function SectionHeader({title}) {
+  return (
+    <View style={styles.sectionDivider}>
+      <Text style={styles.sectionHeader}>{title.toUpperCase()}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {padding: 16, paddingBottom: 40},
+  title: {fontSize: 20, fontWeight: 'bold', color: '#333', marginBottom: 4},
+  subtitle: {fontSize: 13, color: '#8E8E93', marginBottom: 12},
+  btn: {
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#007AFF',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  deadBtn: {borderColor: '#999', backgroundColor: 'rgba(0,0,0,0.03)'},
+  expect: {fontSize: 11, color: '#8E8E93', marginTop: 4, textAlign: 'center'},
+  expectActive: {color: '#007AFF', fontWeight: '600'},
+  rageZone: {
+    height: 80,
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,0,0,0.08)',
+    borderColor: '#FF3B30',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    marginBottom: 8,
+  },
+  label: {fontSize: 16, color: '#333'},
+  sectionDivider: {
+    marginTop: 16,
+    marginBottom: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#C7C7CC',
+    paddingTop: 8,
+  },
+  sectionHeader: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#8E8E93',
+  },
+});

--- a/Samples/MixpanelStarter/src/screens/AutocaptureTestScreen.tsx
+++ b/Samples/MixpanelStarter/src/screens/AutocaptureTestScreen.tsx
@@ -1,0 +1,311 @@
+import React, {useState} from 'react';
+import {
+  Platform,
+  ScrollView,
+  View,
+  Text,
+  TouchableOpacity,
+  Pressable,
+  Switch,
+  TextInput,
+  StyleSheet,
+} from 'react-native';
+
+export function AutocaptureTestScreen() {
+  const [tapCount, setTapCount] = useState(0);
+  const [switchValue, setSwitchValue] = useState(false);
+  const [textValue, setTextValue] = useState('');
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Autocapture Test Screen</Text>
+      <Text style={styles.subtitle}>
+        Run on both iOS and Android. Inspect Mixpanel event stream to verify.
+      </Text>
+
+      {/* ============================================================
+          $el_id Resolution
+
+          What each native SDK does with the props below.
+
+          Android — View path (this is the path React Native uses):
+            1. nativeID           — RN stores the prop as a view tag
+            2. Resource entry name — getResourceEntryName(view.getId());
+               RN's ids are generated at runtime and have no entry name,
+               so testID never resolves here
+            3. <SimpleClassName>_<hash>
+
+          iOS — one path for UIKit and SwiftUI:
+            1. nativeID            — RN exposes it as an ObjC property
+            2. accessibilityIdentifier — RN: testID
+            3. <ClassName>_<hash>
+
+          accessibilityLabel is NOT used, on either platform. It is
+          localized — the same element would report a different id per
+          language — and it can carry user data. It is not reported as a
+          property either: there is no $attr-aria-label.
+
+          The hash is not random: it is derived from the element's position
+          in the hierarchy, so it stays the same across launches for the
+          same layout. It identifies a position, not a row — reordering
+          siblings changes it.
+
+          The one prop that behaves identically on both platforms is
+          nativeID. testID diverges: stable $el_id on iOS, hash on Android.
+
+          NOTE: in a React Native *debug* build every tap resolves to RN's
+          full-screen DebuggingOverlay, so none of these are observable —
+          verify against a release build.
+          ============================================================ */}
+      <SectionHeader title="$el_id Resolution" />
+
+      {/* Case 1: nativeID only — priority 1 on both platforms.
+          `id` is React Native's modern alias: the JS layer copies it onto
+          nativeID (react-native/Libraries/Components/View/View.js), and unlike
+          `nativeID` it is typed on Touchable components. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        id="rn_native_id_btn">
+        <Text>nativeID only</Text>
+        <Expect ios="rn_native_id_btn" android="rn_native_id_btn" />
+      </TouchableOpacity>
+
+      {/* Case 2: nativeID beats everything else, on both platforms. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        id="rn_wins_btn"
+        testID="tid_ignored_btn"
+        accessible={true}
+        accessibilityLabel="al_ignored_btn">
+        <Text>nativeID + testID + accessibilityLabel</Text>
+        <Expect ios="rn_wins_btn" android="rn_wins_btn" />
+      </TouchableOpacity>
+
+      {/* Case 3: testID only — the platform divergence.
+          iOS maps testID to accessibilityIdentifier (priority 2); on Android
+          RN's runtime-generated id has no resource entry name, so the SDK
+          falls through to the structural hash. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={false}
+        testID="tid_only_btn">
+        <Text>testID only</Text>
+        <Expect ios="tid_only_btn" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 4: testID + accessibilityLabel. The label is never a source, so
+          iOS uses the identifier and Android — which cannot resolve RN's id —
+          falls to the hash. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        testID="tid_beats_label_btn"
+        accessibilityLabel="al_never_used">
+        <Text>testID + accessibilityLabel</Text>
+        <Expect ios="tid_beats_label_btn" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 5: accessibilityLabel only — never used as identity, on either
+          platform, and never reported as a property. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        accessibilityLabel="al_only_btn">
+        <Text>accessibilityLabel only (never used)</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 6: a label holding user data. Nothing about it reaches the
+          payload — not $el_id, and there is no $attr-aria-label at all. */}
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        accessibilityLabel="Account ending 4321">
+        <Text>label with user data (PII guard)</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 7: no explicit label, only child text. Frameworks auto-derive a
+          container label from it; that must not surface either. */}
+      <TouchableOpacity style={styles.btn} onPress={() => {}} accessible={false}>
+        <Text>auto-derived label from child text — 4111 1111 1111 1234</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 8: nothing to identify the element — structural hash. Tap it
+          twice across app launches: the id should be the same both times. */}
+      <TouchableOpacity style={styles.btn} onPress={() => {}} accessible={false}>
+        <Text>No nativeID, no testID, no label</Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* Case 9: Pressable carrying a nativeID — same result as
+          TouchableOpacity; resolution is per-view, not per-component. */}
+      <Pressable style={styles.btn} onPress={() => {}} id="pressable_native_id">
+        <Text>Pressable + nativeID</Text>
+        <Expect ios="pressable_native_id" android="pressable_native_id" />
+      </Pressable>
+
+      {/* Case 10: label on a non-interactive child, nothing on the parent.
+          Both SDKs walk up to the nearest clickable ancestor and resolve from
+          there, so identity comes from the parent — which here has none. */}
+      <TouchableOpacity style={styles.btn} onPress={() => {}}>
+        <Text accessible={true} accessibilityLabel="child_text_al">
+          Label on child Text (not on the parent)
+        </Text>
+        <Expect ios="<ClassName>_<hash>" android="ReactViewGroup_<hash>" />
+      </TouchableOpacity>
+
+      {/* ============================================================
+          Click
+          ============================================================ */}
+      <SectionHeader title="Click" />
+
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => {}}
+        accessible={true}
+        accessibilityLabel="click_btn">
+        <Text>Click Button - tap once → $mp_click</Text>
+      </TouchableOpacity>
+
+      {/* ============================================================
+          Dead Click
+          ============================================================ */}
+      <SectionHeader title="Dead Click" />
+
+      <View
+        style={[styles.btn, styles.deadBtn]}
+        accessible={true}
+        accessibilityLabel="dead_rn_btn"
+        accessibilityRole="button">
+        <Text>Dead Button (no onPress) → $mp_dead_click</Text>
+      </View>
+
+      {/* ============================================================
+          Rage Click - tap 4+ times rapidly
+          ============================================================ */}
+      <SectionHeader title="Rage Click - tap 4+ times rapidly" />
+
+      <View
+        style={[styles.btn, styles.rageZone]}
+        accessible={true}
+        accessibilityLabel="rage_zone"
+        accessibilityRole="button">
+        <Text>Rage Zone - tap rapidly (no state change)</Text>
+      </View>
+
+      <TouchableOpacity
+        style={styles.btn}
+        onPress={() => setTapCount(c => c + 1)}
+        accessible={true}
+        accessibilityLabel="rage_and_click_btn">
+        <Text>
+          Click + Rage - tap 4x (both events): {tapCount}x
+        </Text>
+      </TouchableOpacity>
+
+      {/* ============================================================
+          Excluded Controls (no dead click)
+          ============================================================ */}
+      <SectionHeader title="Excluded Controls (no dead click)" />
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Switch</Text>
+        <Switch value={switchValue} onValueChange={setSwitchValue} />
+      </View>
+
+      <TextInput
+        style={styles.input}
+        placeholder="TextInput - no dead click"
+        value={textValue}
+        onChangeText={setTextValue}
+        accessibilityLabel="text_input"
+      />
+    </ScrollView>
+  );
+}
+
+/**
+ * Renders the $el_id each platform is expected to report for the case above it,
+ * highlighting whichever platform the app is currently running on. Keeps the
+ * expectations next to the props that produce them, so a mismatch in the event
+ * stream is obvious without cross-referencing the SDK source.
+ */
+function Expect({ios, android}: {ios: string; android: string}) {
+  const isIOS = Platform.OS === 'ios';
+  return (
+    <Text style={styles.expect}>
+      <Text style={isIOS ? styles.expectActive : undefined}>iOS: {ios}</Text>
+      {'  ·  '}
+      <Text style={isIOS ? undefined : styles.expectActive}>
+        Android: {android}
+      </Text>
+    </Text>
+  );
+}
+
+function SectionHeader({title}: {title: string}) {
+  return (
+    <View style={styles.sectionDivider}>
+      <Text style={styles.sectionHeader}>{title.toUpperCase()}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {padding: 16, paddingBottom: 40},
+  title: {fontSize: 20, fontWeight: 'bold', color: '#333', marginBottom: 4},
+  subtitle: {fontSize: 13, color: '#8E8E93', marginBottom: 12},
+  btn: {
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#007AFF',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  deadBtn: {borderColor: '#999', backgroundColor: 'rgba(0,0,0,0.03)'},
+  expect: {fontSize: 11, color: '#8E8E93', marginTop: 4, textAlign: 'center'},
+  expectActive: {color: '#007AFF', fontWeight: '600'},
+  rageZone: {
+    height: 80,
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,0,0,0.08)',
+    borderColor: '#FF3B30',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    marginBottom: 8,
+  },
+  label: {fontSize: 16, color: '#333'},
+  sectionDivider: {
+    marginTop: 16,
+    marginBottom: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#C7C7CC',
+    paddingTop: 8,
+  },
+  sectionHeader: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#8E8E93',
+  },
+});

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -12,6 +12,26 @@ Autocapture captures three types of events:
 | Rage Click | `$mp_rage_click` | Fired when a user taps rapidly (4+ times) in the same area |
 | Dead Click | `$mp_dead_click` | Fired when a tap produces no visible UI response |
 
+## Requirements
+
+**Autocapture requires native mode.** It is implemented entirely in the native Android and
+iOS SDKs; the JavaScript layer only forwards configuration to them. In JavaScript mode there
+is nothing to forward to, so `autocaptureOptions` is ignored and `init` logs:
+
+> Mixpanel autocapture requires native mode (useNative: true). Autocapture config will be
+> ignored in JavaScript mode.
+
+`useNative` is the third argument to the constructor and defaults to `true`, so most apps get
+it for free. Passing `false` — as an app targeting Expo Go must, since it cannot load custom
+native modules — silently disables autocapture. No events are captured, and no error is
+raised beyond that one warning at startup.
+
+```typescript
+new Mixpanel('YOUR_TOKEN', true);              // native mode, autocapture works
+new Mixpanel('YOUR_TOKEN', true, true);        // explicit, same thing
+new Mixpanel('YOUR_TOKEN', true, false);       // JavaScript mode — autocapture does nothing
+```
+
 ## Quick Start
 
 ```typescript


### PR DESCRIPTION
## What

The autocapture test screens in `MixpanelStarter` and `MixpanelExpo` now cover `$el_id` resolution as it actually behaves — **measured on an Android emulator against a local build of the SDK**, not derived from reading the source.

Ten cases per app, each rendering the expected `$el_id` for both platforms with the running platform highlighted, so a mismatch in the event stream is obvious without cross-referencing the SDK.

```
nativeID  →  resource entry name (Android) / accessibilityIdentifier (iOS)  →  structural hash
```

## Three results that are easy to assume wrong

- **`testID` diverges by platform.** iOS maps it to `accessibilityIdentifier` and reports it; on Android, React Native's ids are generated at runtime and have no resource entry name, so it falls through to the hash. **`nativeID` is the only prop that behaves identically on both platforms.**
- **`accessibilityLabel` is never reported** — not as identity, not as a property. It is localized and can carry user data, and there is no `$attr-aria-label` any more (mixpanel-android#997, mixpanel-swift#767).
- **A label on a non-interactive child never becomes the id.** Both SDKs walk up to the nearest clickable ancestor and resolve from there, so identifiers belong on the pressable element.

## Verified, not assumed

Every case was tapped on a device and the payload read from the event queue. The structural hash claim was checked across app restarts: the same un-instrumented button reported `ReactViewGroup_a424435a` on two separate launches, where the previous identity-based hash changed every session.

## Notes

- These screens are **new files** in the repo — they existed in the working tree but had never been committed.
- They use React Native's `id` prop rather than `nativeID`: the JS layer copies `id` onto `nativeID` (`Libraries/Components/View/View.js`), and unlike `nativeID` it is typed on Touchable components.
- Deliberately **not** included in this PR: `.env` files, iOS/Android build artifacts from `pod install` and `expo prebuild`, and lockfiles that were already dirty in the working tree.

## Also in this PR: making the Expo screen usable

The Expo test screen shipped as dead code — `App.js` never imported or rendered it, so none of the cases above could be opened. (Greptile flagged this as a P1.) The Starter sample wired its copy up through the bottom tab navigator; the Expo one had no entry point.

`App.js` now swaps between the SDK action list and the test screen with a button. A plain toggle rather than a navigator, for two reasons: this sample has no navigation stack, so a navigator would add four dependencies for one screen; and it would change the view hierarchy the screen exists to document — the structural hash behind `$el_id` is derived from a view's ancestors, so wrapping the content in `RNSScreenView` and friends re-keys every hash-based id on it. **No new dependencies.**

## And why the screen still captures nothing

Reaching the screen is necessary but not sufficient. The Expo sample initialises with `useNative = false` and passes no `autocaptureOptions`, and autocapture lives entirely in the native SDKs — in JavaScript mode there is nothing to forward configuration to, so it is ignored and the only signal is one warning at startup.

Nothing said so, in either the sample or `context/AUTOCAPTURE.md`. Both now do: a **Requirements** section above Quick Start, and a comment at the sample's own `useNative` assignment noting that turning it on rules out Expo Go, which cannot load custom native modules.

The flag itself is left as-is — flipping it changes what the sample demonstrates, which is a call for the sample's owner rather than a docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
