### PR TITLE
feat: mark React Native autocapture as experimental (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 
 <!-- /MarkdownTOC -->
 
+> **Autocapture is in beta.** Autocapture — `$mp_click`, `$mp_rage_click` and `$mp_dead_click`, and
+> the `mixpanel.autocapture` API — may contain issues, and its API and the properties it captures may
+> change in a future release before general availability. Pin your SDK version if you build reports
+> on autocaptured events.
+
 ## Introduction
 
 Welcome to the official Mixpanel React Native library.

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,10 +102,20 @@ export interface Flags {
   check_first_time_events(eventName: string, properties?: MixpanelProperties): void;
 }
 
+/**
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties it
+ * captures may change in a future release before general availability. Pin your SDK version if you
+ * build reports on autocaptured events.
+ */
 export interface AutocaptureClickOptions {
   enabled?: boolean;
 }
 
+/**
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties it
+ * captures may change in a future release before general availability. Pin your SDK version if you
+ * build reports on autocaptured events.
+ */
 export interface AutocaptureRageClickOptions {
   enabled?: boolean;
   clickThreshold?: number;
@@ -114,17 +124,32 @@ export interface AutocaptureRageClickOptions {
   radius?: number;
 }
 
+/**
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties it
+ * captures may change in a future release before general availability. Pin your SDK version if you
+ * build reports on autocaptured events.
+ */
 export interface AutocaptureDeadClickOptions {
   enabled?: boolean;
   timeWindowMs?: number;
 }
 
+/**
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties it
+ * captures may change in a future release before general availability. Pin your SDK version if you
+ * build reports on autocaptured events.
+ */
 export interface AutocaptureOptions {
   click?: boolean | AutocaptureClickOptions;
   rageClick?: boolean | AutocaptureRageClickOptions;
   deadClick?: boolean | AutocaptureDeadClickOptions;
 }
 
+/**
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties it
+ * captures may change in a future release before general availability. Pin your SDK version if you
+ * build reports on autocaptured events.
+ */
 export interface ClickEventData {
   /** Touch X coordinate. */
   x: number;
@@ -142,6 +167,11 @@ export interface ClickEventData {
   elements?: string;
 }
 
+/**
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties it
+ * captures may change in a future release before general availability. Pin your SDK version if you
+ * build reports on autocaptured events.
+ */
 export class Autocapture {
   /**
    * Track a screen view event.
@@ -166,6 +196,10 @@ export class Autocapture {
 
 export class Mixpanel {
   readonly flags: Flags;
+  /**
+   * @experimental Autocapture is in **beta** — see {@link Autocapture}. Its API and captured
+   * properties may change before general availability.
+   */
   readonly autocapture: Autocapture;
 
   constructor(token: string, trackAutoMaticEvents: boolean);

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ export class Mixpanel {
    *
    * @return {Autocapture} an instance of Autocapture that provides access to screen view tracking
    *
+   * @experimental Autocapture is in **beta**; its API and captured properties may change before
+   * general availability.
+   *
    * @see Autocapture
    */
   get autocapture() {
@@ -744,6 +747,10 @@ export class Mixpanel {
  * Core class for using Mixpanel Autocapture features.
  *
  * <p>The Autocapture object is used to track screen views and screen leaves.
+ *
+ * @experimental Autocapture is in **beta**. It may contain issues, and its API and the properties
+ * it captures may change in a future release before general availability. Pin your SDK version if
+ * you build reports on autocaptured events.
  */
 export class Autocapture {
   constructor(token, mixpanelImpl) {


### PR DESCRIPTION
## Why

React Native developers never see the native SDKs' documentation, so autocapture's beta status was invisible on this side. This mirrors mixpanel-android#999 and mixpanel-swift#768, with the same wording.

Stacked on #452 — merges into `feat/autocapture-sample-el-id-screens`.

## What changed

- `@experimental` JSDoc on the autocapture typings in `index.d.ts`: `AutocaptureOptions` and its three sub-interfaces, `ClickEventData`, the `Autocapture` class, and `Mixpanel#autocapture`
- the same note on the `Autocapture` class and the `autocapture` getter in `index.js`, so it appears in editor hovers for JavaScript consumers too
- a short callout near the top of the README

No runtime warning is added here on purpose: enabling autocapture goes through the native SDKs, which already log one when it starts, so emitting from JS as well would print it twice.

Documentation only — no API or behaviour change.

## One gap this PR does not close

`index.js:902` still maps `clickEvent.accessibleLabel` onto `$attr-aria-label` for **manual** `trackClick` calls, and `ClickEventData.accessibleLabel` is still in the typings. Both native SDKs stopped capturing and reporting that property (mixpanel-android#997, mixpanel-swift#767) because accessibility labels are localized and can carry user data — so the JS wrapper can currently reintroduce, by hand, the exact property that was deliberately removed.

Fixing it means removing `accessibleLabel` from `ClickEventData` and the property mapping, which is a JS API change and belongs with the label-removal work rather than a docs PR. Happy to open it as a follow-up.

## Testing

The package's jest suite is unchanged: 298 passing, with the same 8 pre-existing failures before and after — verified by stashing these changes and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)