### PR TITLE
feat: depend on published native SDKs, and correct the $el_id docs

### DIFF
--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -20,5 +20,6 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # 6.6.1 is the first release that resolves a React Native `nativeID` into `$el_id`.
-  s.dependency "Mixpanel-swift", '6.6.1'
+  # `~> 6.6.1` picks up 6.6.x patches without an SDK release; 6.7.0 needs a deliberate bump.
+  s.dependency "Mixpanel-swift", '~> 6.6.1'
 end

--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -20,6 +20,5 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # 6.6.1 is the first release that resolves a React Native `nativeID` into `$el_id`.
-  # 6.6.0 shipped autocapture but not that fix, so it is deliberately excluded.
-  s.dependency "Mixpanel-swift", '>= 6.6.1', '< 7.0'
+  s.dependency "Mixpanel-swift", '6.6.1'
 end

--- a/MixpanelReactNative.podspec
+++ b/MixpanelReactNative.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.dependency "React-Core"
-  # Local mixpanel-swift with autocapture support
-  s.dependency "Mixpanel-swift", '~> 6.5'
+  # 6.6.1 is the first release that resolves a React Native `nativeID` into `$el_id`.
+  # 6.6.0 shipped autocapture but not that fix, so it is deliberately excluded.
+  s.dependency "Mixpanel-swift", '>= 6.6.1', '< 7.0'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,6 @@ android {
 }
 
 repositories {
-    mavenLocal() // Local builds of mixpanel-android with autocapture support
     mavenCentral()
     maven {
         url 'https://maven.google.com/'
@@ -42,6 +41,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    // Local mixpanel-android with autocapture support (publish locally with: ./gradlew :analytics:publishToMavenLocal -x signReleasePublication)
-    implementation 'com.mixpanel.android:mixpanel-android:9.0.0-beta'
+    // 8.10.0 is the first release carrying autocapture.
+    implementation 'com.mixpanel.android:mixpanel-android:8.10.0'
 }

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -54,29 +54,69 @@ await mixpanel.init(
 
 ## Element Identification (`$el_id`)
 
+### Resolution Order
+
+| Priority | iOS | Android |
+|---|---|---|
+| 1 | `nativeID` | `nativeID` |
+| 2 | `accessibilityIdentifier` (React Native's `testID`) | resource entry name — React Native's ids are generated at runtime and have none, so `testID` never resolves here |
+| 3 | `<ClassName>_<hash>` | `<SimpleClassName>_<hash>` |
+
+**`accessibilityLabel` is never used as identity, on either platform.** It is user-facing
+text: localized, so the same element would report a different id per language, and capable
+of carrying personal data. It is not reported as a property either.
+
+The hash is not random — it is derived from the element's position in the view hierarchy, so
+it is stable across launches for the same layout. It identifies a *position*, not a row:
+reordering siblings changes it, and so does wrapping the screen in a navigator.
+
 ### Walk-Up to Clickable Parent
 
-When a non-interactive leaf view (e.g., `<Text>` inside a `<Pressable>`) is tapped, the native SDK walks up the view hierarchy to the nearest clickable ancestor and uses its `accessibilityLabel` for `$el_id`. This is always-on behavior — not configurable.
+Hit-testing returns the deepest view, so tapping a `<Pressable>` usually reports its `<Text>`
+child, which carries no identity of its own. The native SDK therefore walks up to the nearest
+clickable ancestor and resolves the id from there. This is always-on — not configurable.
 
-- The walk-up always takes the clickable parent's identity, even if the leaf has its own `accessibilityLabel`.
+- The clickable parent's identity wins, even when the leaf has one of its own.
 - Stops at the first clickable ancestor (nested clickables: inner wins).
-- Max ancestor search depth: **10 levels**.
-- If no clickable ancestor is found within 10 levels, the leaf's own identity (or hash fallback) is used.
+- Max ancestor search depth: **10 levels**; beyond that the leaf's own identity (or hash) is used.
+- On iOS, if no *clickable* ancestor is found, the nearest ancestor carrying a `nativeID` or
+  `testID` is used instead, so a named pressable is still attributed correctly.
 
-React Native's view flattening compounds this — intermediate `<View>` wrappers are removed from the native tree, so the platform's hit-test often returns a leaf `Text` node even when the developer intended the tap for the parent `Pressable`.
+### Dead Clicks Need an Explicit Role on iOS
+
+`$mp_dead_click` is only reported for elements the platform can recognise as interactive.
+
+On Android that is automatic: React Native sets `focusable` on `Pressable` and the
+`Touchable*` family, which attaches an `OnClickListener`, and the SDK keys off
+`hasOnClickListeners()` / `isClickable()`.
+
+iOS has no equivalent. React Native dispatches every touch from a single recognizer on the
+surface root, so a pressable has no `UIControl`, no gesture recognizer, and no accessibility
+trait — it is indistinguishable from a plain `<View>`. A `nativeID` does not help: identifiers
+are applied to layout wrappers and test hooks as often as to buttons, so treating one as proof
+of clickability would report dead clicks on elements that were never meant to respond.
+
+**Set `accessibilityRole="button"` on interactive wrappers to get dead click detection on
+iOS.** It is also what VoiceOver needs in order to announce the element as actionable. Note
+that `accessible={true}` does *not* substitute for it — that only marks the view as an
+accessibility element and is already the default for `Pressable` and `Touchable*`.
 
 ### Best Practice
 
-Set `accessibilityLabel` on interactive wrappers (`Pressable`, `TouchableOpacity`):
+Set both on the *same* element: `nativeID` for a stable `$el_id`, `accessibilityRole` for dead
+click detection.
 
 ```tsx
 <Pressable
   onPress={handlePress}
-  accessible={true}
-  accessibilityLabel="add_to_cart">
+  nativeID="add_to_cart"
+  accessibilityRole="button">
   <Text>Add to Cart</Text>
 </Pressable>
 ```
+
+If the role sits on a wrapper and the `nativeID` on an inner element, the clickable ancestor
+wins for attribution and the inner identifier is dropped — hence "same element".
 
 ## Configuration Options
 

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -79,12 +79,16 @@ clickable ancestor and resolves the id from there. This is always-on — not con
 - The clickable parent's identity wins, even when the leaf has one of its own.
 - Stops at the first clickable ancestor (nested clickables: inner wins).
 - Max ancestor search depth: **10 levels**; beyond that the leaf's own identity (or hash) is used.
-- On iOS, if no *clickable* ancestor is found, the nearest ancestor carrying a `nativeID` or
-  `testID` is used instead, so a named pressable is still attributed correctly.
+- If no clickable ancestor is found, the tapped element's own identity is used. The walk-up keys
+  off interactivity only — a named but non-clickable wrapper never absorbs a click that landed on
+  its child. This is identical on both platforms.
 
-### Dead Clicks Need an Explicit Role on iOS
+### iOS Pressables Need an Explicit Role
 
-`$mp_dead_click` is only reported for elements the platform can recognise as interactive.
+On iOS the walk-up finds nothing for a React Native pressable, which costs you both halves: the
+tap resolves to the `<Text>` inside the button rather than to the button, so `$el_id` is a hash
+rather than your `nativeID`; and `$mp_dead_click` is only reported for elements the platform can
+recognise as interactive, so none is reported at all.
 
 On Android that is automatic: React Native sets `focusable` on `Pressable` and the
 `Touchable*` family, which attaches an `OnClickListener`, and the SDK keys off
@@ -96,15 +100,22 @@ trait — it is indistinguishable from a plain `<View>`. A `nativeID` does not h
 are applied to layout wrappers and test hooks as often as to buttons, so treating one as proof
 of clickability would report dead clicks on elements that were never meant to respond.
 
-**Set `accessibilityRole="button"` on interactive wrappers to get dead click detection on
-iOS.** It is also what VoiceOver needs in order to announce the element as actionable. Note
-that `accessible={true}` does *not* substitute for it — that only marks the view as an
-accessibility element and is already the default for `Pressable` and `Touchable*`.
+**Set `accessibilityRole="button"` on interactive wrappers.** It sets the underlying
+`UIAccessibilityTraitButton`, which makes the pressable discoverable: the walk-up then finds it,
+resolves its `nativeID`, and dead click detection applies to it. It is also what VoiceOver needs
+in order to announce the element as actionable.
+
+Note that `accessible={true}` does *not* substitute for it — that only marks the view as an
+accessibility element, and is already the default for `Pressable` and `Touchable*`.
+
+Android needs none of this: React Native sets `focusable` there, so the pressable is genuinely
+clickable and both `$el_id` and dead clicks work without the role. Until you add it, expect the
+same app to report ids and dead clicks on Android that it does not report on iOS.
 
 ### Best Practice
 
-Set both on the *same* element: `nativeID` for a stable `$el_id`, `accessibilityRole` for dead
-click detection.
+Set both on the *same* element. `nativeID` supplies the identity; on iOS `accessibilityRole`
+is what lets the SDK reach it, and it enables dead click detection on both counts.
 
 ```tsx
 <Pressable


### PR DESCRIPTION
> **Stacked on #453.**

## Summary

Two things that both block a clean checkout from using autocapture: the native SDKs were still wired to unpublished local builds, and the `$el_id` documentation described behaviour the SDKs do not implement.

## 1. Depend on published native SDKs

The Android dependency pointed at `mixpanel-android:9.0.0-beta` resolved through `mavenLocal()`, and the iOS podspec allowed any `~> 6.5` behind a comment describing it as "Local mixpanel-swift with autocapture support". Neither resolves for anyone who has not built the native SDKs by hand — a fresh clone could not build the Android module at all.

Both features are now released, so the local wiring can go:

| | was | now | |
| --- | --- | --- | --- |
| Android | `9.0.0-beta` via `mavenLocal()` | `8.10.0` | Maven Central `<release>` |
| iOS | `~> 6.5` | `~> 6.6.1` | 6.6.1 is the first release that resolves a React Native `nativeID` into `$el_id` |

The iOS pin is `6.6.1`, not `6.6.0`. 6.6.0 shipped autocapture but not the `$el_id` resolution, so on it a `nativeID` never reaches `$el_id` under the new architecture.

`~> 6.6.1` resolves to `>= 6.6.1, < 6.7.0`. Note that adding the third component tightens the ceiling — `~> 6.5` meant `< 7.0`, `~> 6.6.1` means `< 6.7.0` — so a 6.7.0 needs a deliberate bump here, which seems right while autocapture is in beta.

Earlier revisions of this PR tried `>= 6.6.1, < 7.0` and then an exact `6.6.1`. The optimistic operator is the better fit: it picks up 6.6.x patches without needing an SDK release (mixpanel-swift shipped 6.4.1 and 6.5.1 this year), and unlike an exact pin it will not deadlock resolution for an app that also depends on Mixpanel-swift directly or through `@mixpanel/react-native-session-replay`.

The Android version number goes *down*, from `9.0.0-beta` to `8.10.0`. That is not a downgrade: the beta was a local build, and 8.10.0 is the released version of the same work.

Verified before repinning: `v8.10.0` ships `AutocaptureOptions`, `ClickOptions`, `RageClickOptions` and `DeadClickOptions`, and its `Builder` API matches every call this module makes (`new AutocaptureOptions.Builder()`, `.clickOptions()`, `.rageClickOptions()`, `.deadClickOptions()`, `.build()`). `mavenLocal()` and both local-build comments are removed; the remaining `:path =>` entries in the sample Podfiles are standard React Native boilerplate for `node_modules/react-native`, not Mixpanel.

## 2. Correct the `$el_id` resolution rules

The `$el_id` section of `context/AUTOCAPTURE.md` said the walk-up

> uses its `accessibilityLabel` for `$el_id`

and **Best Practice** told developers to set `accessibilityLabel` on interactive wrappers.

`accessibilityLabel` is the one property both SDKs deliberately never read for identity: it is localized, so the same element would report a different id per language, and it can carry user data. A developer following that guidance gets a structural hash and reasonably concludes autocapture is broken. It also contradicts the sample screens added in #452, which already state that the label is not used on either platform.

Changes:

- **Resolution order**, as a per-platform table: `nativeID` → `accessibilityIdentifier` (`testID`) on iOS or the resource entry name on Android → positional hash. With an explicit note that `accessibilityLabel` is never identity, and why.
- **Hash semantics** — it tracks a *position*, not a row, so reordering siblings or wrapping a screen in a navigator re-keys it. Worth knowing before restructuring a screen you already have reports on.
- **Best Practice rewritten** to `nativeID`, and to put it on the same element as the role, since a clickable ancestor outranks anything below it.
- **New: iOS pressables need an explicit role.** This gates *both* halves, not just frustration signals: without `accessibilityRole="button"` a React Native pressable is invisible to UIKit, so the tap resolves to the `<Text>` inside the button — `$el_id` is a positional hash rather than your `nativeID` — *and* no dead click is reported. Android gets it automatically — React Native sets `focusable` on `Pressable`/`Touchable*`, which attaches an `OnClickListener`, and the SDK keys off `hasOnClickListeners()`/`isClickable()`. iOS has no equivalent: touches are dispatched from a single recognizer on the surface root, leaving a pressable indistinguishable from a plain `<View>`. Records that `accessible={true}` is not a substitute — it only sets `isAccessibilityElement` and is already the default for `Pressable` and `Touchable*`.
- **Removed** the claim that view flattening strips the wrapper from the native tree. Hit-testing returns the deepest view regardless, and a pressable carrying interaction props is not flattened away.

## Note on sequencing

**`Mixpanel-swift 6.6.1` is not published yet**, so `pod install` will not resolve against this podspec until it goes out. That is intentional — the pin names the version that will carry the fix — but it means this PR is blocked on that release.

The iOS behaviour documented here is implemented by mixpanel-swift **#781, still open**. That PR narrowed during review: an earlier revision resolved `$el_id` from the nearest ancestor carrying an identifier when no clickable ancestor was found, which diverged from Android and let a named but non-clickable container absorb clicks landing on its children. It was reverted, so the walk-up is keyed to interactivity on both platforms and `accessibilityRole="button"` is what a React Native pressable needs on iOS. This documentation follows the reverted, final behaviour.

Merge order should be: #781 → release 6.6.1 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



